### PR TITLE
merges from https://bitbucket.org/jpommier/pffft/src/master/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option(USE_BENCH_FFTW   "use (system-installed) FFTW3 in fft benchmark?" OFF)
 option(USE_BENCH_GREEN  "use Green FFT in fft benchmark? - if exists in subdir" ON)
 option(USE_BENCH_KISS   "use KissFFT in fft benchmark? - if exists in subdir" ON)
 option(USE_BENCH_POCKET "use PocketFFT in fft benchmark? - if exists in subdir" ON)
+option(USE_BENCH_MKL    "use Intel MKL in fft benchmark? needs to be installed" OFF)
 option(USE_FFTPACK      "compile and use FFTPACK in fft benchmark & validation?" ON)
 
 option(USE_DEBUG_ASAN  "use GCC's address sanitizer?" OFF)
@@ -334,6 +335,17 @@ if (USE_TYPE_FLOAT)
     target_link_libraries(bench_pffft_float  PocketFFT)
   endif()
 
+  if (USE_BENCH_MKL)
+    if ( (CMAKE_SYSTEM_PROCESSOR STREQUAL "i686") OR (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64") )
+      # has chances to work
+    else()
+      # other PROCESSORs could be "ppc", "ppc64",  "arm", "aarch64" - or something else?!
+      message(WARNING "using Intel MKL on '${CMAKE_SYSTEM_PROCESSOR}' might fail.")
+    endif()
+    message(STATUS "In case compiling/linking with Intel MKL fails, check CMakeLists.txt or deactivate USE_BENCH_MKL")
+    target_compile_definitions(bench_pffft_float PRIVATE HAVE_MKL=1)
+    target_link_libraries(bench_pffft_float  mkl_intel_lp64 mkl_sequential -lmkl_core)
+  endif()
 endif()
 
 if (USE_TYPE_DOUBLE)
@@ -355,6 +367,18 @@ if (USE_TYPE_DOUBLE)
   if (PATH_POCKET AND USE_BENCH_POCKET)
     target_compile_definitions(bench_pffft_double PRIVATE HAVE_POCKET_FFT=1)
     target_link_libraries(bench_pffft_double  PocketFFT)
+  endif()
+
+  if (USE_BENCH_MKL)
+    if ( (CMAKE_SYSTEM_PROCESSOR STREQUAL "i686") OR (CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64") )
+      # has chances to work
+    else()
+      # other PROCESSORs could be "ppc", "ppc64",  "arm", "aarch64" - or something else?!
+      message(WARNING "using Intel MKL on '${CMAKE_SYSTEM_PROCESSOR}' might fail.")
+    endif()
+    message(STATUS "In case compiling/linking with Intel MKL fails, check CMakeLists.txt or deactivate USE_BENCH_MKL")
+    target_compile_definitions(bench_pffft_double PRIVATE HAVE_MKL=1)
+    target_link_libraries(bench_pffft_double  mkl_intel_lp64 mkl_sequential -lmkl_core)
   endif()
 endif()
 

--- a/simd/pf_sse1_float.h
+++ b/simd/pf_sse1_float.h
@@ -36,7 +36,7 @@
 /*
   SSE1 support macros
 */
-#if !defined(SIMD_SZ) && !defined(PFFFT_SIMD_DISABLE) && (defined(__x86_64__) || defined(_M_X64) || defined(i386) || defined(_M_IX86))
+#if !defined(SIMD_SZ) && !defined(PFFFT_SIMD_DISABLE) && (defined(__x86_64__) || defined(_M_X64) || defined(__i386__) || defined(i386) || defined(_M_IX86))
 #pragma message( __FILE__ ": SSE1 float macros are defined" )
 
 #include <xmmintrin.h>

--- a/test_pffft.c
+++ b/test_pffft.c
@@ -1,7 +1,7 @@
 /*
   Copyright (c) 2013 Julien Pommier.
 
-  Small test & bench for PFFFT, comparing its performance with the scalar FFTPACK, FFTW, and Apple vDSP
+  Small test for PFFFT
 
   How to build: 
 


### PR DESCRIPTION
* fix: add define for 32bit x86 iOS simulator

* Add MKL to the benchmark
* added cmake option 'USE_BENCH_MKL', defaults to off
* added double variant for MKL
* ubuntu linux requires 'sudo apt-get install intel-mkl'
