### PR TITLE
chore: migrate to `ubuntu-24.04` to prevent CI failures

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -72,7 +72,7 @@ jobs:
         path: pffft_ubuntu-amd64.tar.gz
 
   cross_build_win_from_linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: prerequisites

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -72,7 +72,7 @@ jobs:
         path: pffft_ubuntu-amd64.tar.gz
 
   cross_build_win_from_linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: prerequisites


### PR DESCRIPTION
The CI failure in #76 is due to the retirement of `ubuntu-20.04`, as given here: https://github.com/actions/runner-images/issues/11101.

This PR updates it to `ubuntu-24.04`, as given in the above reference issue.

Ref:

> Workflows using the ubuntu-20.04 image label should be updated to ubuntu-latest, ubuntu-22.04, ubuntu-24.04 .