### PR TITLE
Fix #90: Do not #undef __STRICT_ANSI__

### DIFF
--- a/src/pf_cic.cpp
+++ b/src/pf_cic.cpp
@@ -28,9 +28,6 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-/* gcc requires this for M_PI !? */
-#undef __STRICT_ANSI__
-
 /* include own header first, to see missing includes */
 #include "pf_cic.h"
 #include "fmv.h"


### PR DESCRIPTION
Basically what it says - and it prevents emitting a warning when compiling on gcc/clang. See #90.