### PR TITLE
cmake: guard uninstall target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,9 +336,11 @@ if (INSTALL_TARGETS)
   )
 endif()
 
-add_custom_target(uninstall
-    "${CMAKE_COMMAND}" -P "${CMAKE_SOURCE_DIR}/uninstall.cmake"
-)
+if (PFFFT_IS_TOPLEVEL AND NOT TARGET uninstall)
+  add_custom_target(uninstall
+      "${CMAKE_COMMAND}" -P "${CMAKE_SOURCE_DIR}/uninstall.cmake"
+  )
+endif()
 
 ######################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,12 +334,11 @@ if (INSTALL_TARGETS)
     "${CMAKE_CURRENT_BINARY_DIR}/pffft-config-version.cmake"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/pffft
   )
-endif()
-
-if (PFFFT_IS_TOPLEVEL AND NOT TARGET uninstall)
-  add_custom_target(uninstall
-      "${CMAKE_COMMAND}" -P "${CMAKE_SOURCE_DIR}/uninstall.cmake"
-  )
+  if (PFFFT_IS_TOPLEVEL AND NOT TARGET uninstall)
+    add_custom_target(uninstall
+        "${CMAKE_COMMAND}" -P "${CMAKE_SOURCE_DIR}/uninstall.cmake"
+    )
+  endif()
 endif()
 
 ######################################################

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ see [https://cmake.org/cmake/help/v3.15/manual/cmake-generators.7.html#visual-st
 ## Using pffft in your CMake project
 
 pffft can be included as a dependency in your CMake project via `FetchContent` or `add_subdirectory()`. When used this way, tests, benchmarks, and examples are automatically disabled, so pffft won't pollute your build or ctest runner with unnecessary targets.
+The standalone `uninstall` helper target is also only created for top-level builds, which avoids target-name collisions with other dependencies that follow the same convention.
 
 ### FetchContent (CMake 3.11+)
 
@@ -445,4 +446,3 @@ an explanation of why the change was not ported.
 | 2025-02-12 | `0d7449a` | Dan Raviv | Fix MSVC `/fp:strict` C2099 errors | `4d1c78d` | cherry-picked |
 | 2025-12-19 | `c306b13` | Julien Pommier | Fix implicit double-to-float conversions | `31be131` | cherry-picked (fftpack.c portion) |
 | 2026-01-05 | `0979688` | Julien Pommier | Fix alignment for small `size_t` platforms | `a9786ad` | already uses `uintptr_t` |
-

--- a/README.md
+++ b/README.md
@@ -172,8 +172,7 @@ see [https://cmake.org/cmake/help/v3.15/manual/cmake-generators.7.html#visual-st
 
 ## Using pffft in your CMake project
 
-pffft can be included as a dependency in your CMake project via `FetchContent` or `add_subdirectory()`. When used this way, tests, benchmarks, and examples are automatically disabled, so pffft won't pollute your build or ctest runner with unnecessary targets.
-The standalone `uninstall` helper target is also only created for top-level builds, which avoids target-name collisions with other dependencies that follow the same convention.
+pffft can be included as a dependency in your CMake project via `FetchContent` or `add_subdirectory()`. When used this way, tests, benchmarks, examples, and the standalone `uninstall` helper target are automatically disabled, so pffft won't pollute your build or ctest runner with unnecessary targets or cause target-name collisions.
 
 ### FetchContent (CMake 3.11+)
 


### PR DESCRIPTION
When using PFFFT as a submodule/FetchContent, other subprojects may create an uninstall target that conflicts with the unconditional uninstall target that PFFFT was creating.

Fix it by only creating the uninstall target if PFFFT is a top-level, and no other uninstall target has been created (just in case).