### PR TITLE
RISC-V Vector (RVV 1.0) SIMD support

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -28,6 +28,31 @@ jobs:
     - name: test
       run: cd build_wasm && ctest --output-on-failure
 
+  build_riscv64_qemu:
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: install riscv64 cross toolchain and qemu
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-riscv64-linux-gnu g++-riscv64-linux-gnu qemu-user-static
+    - name: cmake configure
+      run: |
+        cmake -S . -B build_riscv64 \
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -DCMAKE_SYSTEM_NAME=Linux \
+          -DCMAKE_SYSTEM_PROCESSOR=riscv64 \
+          -DCMAKE_C_COMPILER=riscv64-linux-gnu-gcc \
+          -DCMAKE_CXX_COMPILER=riscv64-linux-gnu-g++ \
+          -DCMAKE_CROSSCOMPILING_EMULATOR=qemu-riscv64-static \
+          -DPFFFT_USE_BENCH_GREEN=OFF -DPFFFT_USE_BENCH_KISS=OFF -DPFFFT_USE_BENCH_POCKET=OFF \
+          -DPFFFT_BUILD_TESTS=ON -DPFFFT_BUILD_BENCHMARKS=OFF -DPFFFT_BUILD_EXAMPLES=OFF
+    - name: build
+      run: cmake --build build_riscv64
+    - name: test
+      run: cd build_riscv64 && ctest --output-on-failure
+
   build_w_mipp_ubuntu-amd64:
     runs-on: ubuntu-latest
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,8 +140,8 @@ if (MINGW)
 endif()
 
 
-set( SIMD_FLOAT_HDRS ${PFFFT_SOURCE_DIR}/src/simd/pf_float.h ${PFFFT_SOURCE_DIR}/src/simd/pf_sse1_float.h ${PFFFT_SOURCE_DIR}/src/simd/pf_altivec_float.h ${PFFFT_SOURCE_DIR}/src/simd/pf_neon_float.h ${PFFFT_SOURCE_DIR}/src/simd/pf_scalar_float.h )
-set( SIMD_DOUBLE_HDRS ${PFFFT_SOURCE_DIR}/src/simd/pf_double.h ${PFFFT_SOURCE_DIR}/src/simd/pf_avx_double.h ${PFFFT_SOURCE_DIR}/src/simd/pf_scalar_double.h )
+set( SIMD_FLOAT_HDRS ${PFFFT_SOURCE_DIR}/src/simd/pf_float.h ${PFFFT_SOURCE_DIR}/src/simd/pf_sse1_float.h ${PFFFT_SOURCE_DIR}/src/simd/pf_altivec_float.h ${PFFFT_SOURCE_DIR}/src/simd/pf_neon_float.h ${PFFFT_SOURCE_DIR}/src/simd/pf_rvv_float.h ${PFFFT_SOURCE_DIR}/src/simd/pf_scalar_float.h )
+set( SIMD_DOUBLE_HDRS ${PFFFT_SOURCE_DIR}/src/simd/pf_double.h ${PFFFT_SOURCE_DIR}/src/simd/pf_avx_double.h ${PFFFT_SOURCE_DIR}/src/simd/pf_rvv_double.h ${PFFFT_SOURCE_DIR}/src/simd/pf_scalar_double.h )
 
 if (PFFFT_USE_TYPE_FLOAT)
   set( FLOAT_SOURCES src/pffft.c include/pffft/pffft.h ${SIMD_FLOAT_HDRS} )

--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@
 PFFFT does 1D Fast Fourier Transforms, of single precision real and
 complex vectors. It tries do it fast, it tries to be correct, and it
 tries to be small. Computations do take advantage of SSE1/AVX/AVX2 instructions
-on x86 cpus, Altivec on powerpc cpus, and NEON on ARM cpus
-(including Apple Silicon). The license is BSD-like.
+on x86 cpus, Altivec on powerpc cpus, NEON on ARM cpus
+(including Apple Silicon), and the RVV 1.0 vector extension on RISC-V cpus.
+The license is BSD-like.
 
 PFFFT is a fork of [Julien Pommier's library on bitbucket](https://bitbucket.org/jpommier/pffft/)
 with some changes and additions.
@@ -136,7 +137,7 @@ sudo apt-get install cmake-curses-gui
 Some of the options:
 * `PFFFT_USE_TYPE_FLOAT` to activate single precision 'float' (default: ON)
 * `PFFFT_USE_TYPE_DOUBLE` to activate 'double' precision float (default: ON)
-* `PFFFT_USE_SIMD` to use SIMD (SSE/AVX/NEON/ALTIVEC/WASM SIMD) CPU features? (default: ON)
+* `PFFFT_USE_SIMD` to use SIMD (SSE/AVX/NEON/ALTIVEC/WASM SIMD/RVV) CPU features? (default: ON)
 * `DISABLE_SIMD_AVX` to disable AVX CPU features (default: OFF)
 * `PFFFT_USE_SIMD_NEON` to force using NEON on ARM (requires PFFFT_USE_SIMD) (default: OFF)
 * `PFFFT_USE_SCALAR_VECT` to use 4-element vector scalar operations (if no other SIMD) (default: ON)
@@ -180,6 +181,16 @@ ctest
 ```
 
 WASM SIMD is enabled automatically. Emscripten provides NEON-to-WASM SIMD translation via [SIMDe](https://github.com/simd-everywhere/simde) (SIMD Everywhere) compatibility headers, so pffft's NEON code paths are reused for WebAssembly.
+
+### Building on RISC-V
+
+When the host is detected as `riscv64`, the build defaults to
+`-march=rv64gcv` and defines `PFFFT_ENABLE_RVV`, enabling the
+RVV 1.0 vector backend in `src/simd/pf_rvv_{float,double}.h`. On
+hardware with `VLEN >= 256` (e.g. Spacemit X100) the configure step
+also probes the host VLEN and appends a `zvlNNNb` suffix so the
+compiler can emit single 4-wide double-precision vector ops. To opt
+out, pass `-DPFFFT_USE_SIMD=OFF` or set `-DTARGET_C_ARCH=rv64gc`.
 
 ## Using pffft in your CMake project
 

--- a/cmake/target_optimizations.cmake
+++ b/cmake/target_optimizations.cmake
@@ -62,6 +62,12 @@ elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "armv7l")
     set(GCC_MARCH_DESC "native/ARMwNEON:armv7-a")
     set(GCC_MARCH_VALUES "none;native;armv7-a" CACHE INTERNAL "List of possible architectures")
     set(GCC_EXTRA_VALUES "none;neon_vfpv4;neon_rpi3_a53;neon_rpi4_a72" CACHE INTERNAL "List of possible additional options")
+elseif (CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
+    # RISC-V with the V (vector) extension; rv64gcv enables the standard
+    # G+C profile plus V (RVV 1.0). pf_rvv_*.h is gated on __riscv_vector.
+    set(GCC_MARCH_DESC "native/RISCVwRVV:rv64gcv")
+    set(GCC_MARCH_VALUES "none;native;rv64gc;rv64gcv" CACHE INTERNAL "List of possible architectures")
+    set(GCC_EXTRA_VALUES "" CACHE INTERNAL "List of possible additional options")
 elseif (EMSCRIPTEN)
     # Emscripten WASM SIMD is handled automatically in target_set_c/cxx_arch_flags
     set(GCC_MARCH_DESC "wasm-simd")
@@ -121,6 +127,61 @@ endif()
 
 ######################################################
 
+# Pick an -march string for RISC-V and report whether the V extension
+# is available. We compile and run a tiny probe against -march=rv64gcv:
+#
+#   - if compile + run succeed, the target supports V; the probe prints
+#     the host VLEN, and if VLEN >= 256 we append the matching zvlNNNb
+#     so the compiler can emit single-instruction 4-wide double ops
+#     instead of splitting them into VLEN_min=128 pieces;
+#   - if compile or run fails, the target lacks V; we fall back to
+#     plain rv64gc and the caller is expected to skip PFFFT_ENABLE_RVV
+#     so the headers stay on the scalar path.
+#
+# The probe runs natively or under CMAKE_CROSSCOMPILING_EMULATOR (e.g.
+# qemu-riscv64-static). When neither applies (bare cross-compile) we
+# optimistically default to rv64gcv with has_v=TRUE; users targeting
+# non-V cores should set TARGET_C_ARCH=rv64gc explicitly.
+function(_pffft_riscv_march out_march out_has_v)
+    if (NOT DEFINED PFFFT_RVV_HAS_V
+        AND (NOT CMAKE_CROSSCOMPILING OR CMAKE_CROSSCOMPILING_EMULATOR))
+        set(_probe "${CMAKE_CURRENT_BINARY_DIR}/pffft_rvv_vlen_probe.c")
+        file(WRITE "${_probe}"
+            "#include <stdio.h>\n"
+            "#include <riscv_vector.h>\n"
+            "int main(void){ printf(\"%zu\\n\", __riscv_vsetvlmax_e32m1() * 32); return 0; }\n")
+        try_run(_run_res _compile_ok
+            "${CMAKE_CURRENT_BINARY_DIR}/rvv_vlen_probe"
+            "${_probe}"
+            COMPILE_DEFINITIONS "-march=rv64gcv"
+            RUN_OUTPUT_VARIABLE _vlen)
+        if (_compile_ok AND _run_res EQUAL 0)
+            string(STRIP "${_vlen}" _vlen)
+            set(PFFFT_RVV_HAS_V TRUE CACHE INTERNAL "Target supports the RISC-V V extension")
+            set(PFFFT_RVV_VLEN "${_vlen}" CACHE INTERNAL "Detected RISC-V VLEN in bits")
+        else()
+            set(PFFFT_RVV_HAS_V FALSE CACHE INTERNAL "Target lacks the RISC-V V extension")
+        endif()
+    endif()
+
+    if (DEFINED PFFFT_RVV_HAS_V AND NOT PFFFT_RVV_HAS_V)
+        set(${out_march} "rv64gc" PARENT_SCOPE)
+        set(${out_has_v} FALSE PARENT_SCOPE)
+    elseif (PFFFT_RVV_VLEN AND PFFFT_RVV_VLEN GREATER_EQUAL 256)
+        set(${out_march} "rv64gcv_zvl${PFFFT_RVV_VLEN}b" PARENT_SCOPE)
+        set(${out_has_v} TRUE PARENT_SCOPE)
+    else()
+        set(${out_march} "rv64gcv" PARENT_SCOPE)
+        set(${out_has_v} TRUE PARENT_SCOPE)
+    endif()
+endfunction()
+
+# Matches RISC-V march strings that include the V extension. Examples:
+#   rv64gcv, rv64gcv_zvl256b, rv64imafdcv, rv32gc_v, rv64gc_v_zvl128b.
+# Deliberately does NOT match plain rv64gc / rv64imafdc — the leading
+# "rv" alone is not enough to claim the V extension.
+set(PFFFT_RVV_MARCH_REGEX "rv[0-9]+[a-z_]*v($|_)")
+
 function(target_set_c_arch_flags target)
     # Emscripten WASM SIMD via NEON emulation
     if (EMSCRIPTEN)
@@ -128,6 +189,25 @@ function(target_set_c_arch_flags target)
         target_compile_options(${target} PRIVATE "-msimd128")
         target_compile_definitions(${target} PRIVATE PFFFT_ENABLE_NEON=1)
         return()
+    endif()
+    # On RISC-V the V extension is opt-in via -march; auto-enable RVV
+    # when we can verify the target supports V, and skip it otherwise
+    # so a non-V target still gets a usable rv64gc build.
+    if (CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
+        if ( ("${TARGET_C_ARCH}" STREQUAL "") OR ("${TARGET_C_ARCH}" STREQUAL "none") )
+            _pffft_riscv_march(_rvv_march _rvv_has_v)
+            target_compile_options(${target} PRIVATE "-march=${_rvv_march}")
+            if (_rvv_has_v)
+                target_compile_definitions(${target} PRIVATE PFFFT_ENABLE_RVV=1)
+                message(STATUS "RISC-V detected: defaulting C target ${target} to -march=${_rvv_march} with PFFFT_ENABLE_RVV")
+            else()
+                message(STATUS "RISC-V detected (no V extension): defaulting C target ${target} to -march=${_rvv_march}")
+            endif()
+            return()
+        elseif ("${TARGET_C_ARCH}" MATCHES "${PFFFT_RVV_MARCH_REGEX}")
+            target_compile_definitions(${target} PRIVATE PFFFT_ENABLE_RVV=1)
+            message(STATUS "RISC-V detected: enabling PFFFT_ENABLE_RVV for C target ${target}")
+        endif()
     endif()
     if ( ("${TARGET_C_ARCH}" STREQUAL "") OR ("${TARGET_C_ARCH}" STREQUAL "none") )
         message(STATUS "C ARCH for target ${target} is not set!")
@@ -168,6 +248,22 @@ function(target_set_cxx_arch_flags target)
         target_compile_options(${target} PRIVATE "-msimd128")
         target_compile_definitions(${target} PRIVATE PFFFT_ENABLE_NEON=1)
         return()
+    endif()
+    if (CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
+        if ( ("${TARGET_CXX_ARCH}" STREQUAL "") OR ("${TARGET_CXX_ARCH}" STREQUAL "none") )
+            _pffft_riscv_march(_rvv_march _rvv_has_v)
+            target_compile_options(${target} PRIVATE "-march=${_rvv_march}")
+            if (_rvv_has_v)
+                target_compile_definitions(${target} PRIVATE PFFFT_ENABLE_RVV=1)
+                message(STATUS "RISC-V detected: defaulting C++ target ${target} to -march=${_rvv_march} with PFFFT_ENABLE_RVV")
+            else()
+                message(STATUS "RISC-V detected (no V extension): defaulting C++ target ${target} to -march=${_rvv_march}")
+            endif()
+            return()
+        elseif ("${TARGET_CXX_ARCH}" MATCHES "${PFFFT_RVV_MARCH_REGEX}")
+            target_compile_definitions(${target} PRIVATE PFFFT_ENABLE_RVV=1)
+            message(STATUS "RISC-V detected: enabling PFFFT_ENABLE_RVV for C++ target ${target}")
+        endif()
     endif()
     if ( ("${TARGET_CXX_ARCH}" STREQUAL "") OR ("${TARGET_CXX_ARCH}" STREQUAL "none") )
         message(STATUS "C++ ARCH for target ${target} is not set!")

--- a/src/simd/pf_double.h
+++ b/src/simd/pf_double.h
@@ -62,6 +62,7 @@ typedef double vsfscalar;
 #include "pf_avx_double.h"
 #include "pf_sse2_double.h"
 #include "pf_neon_double.h"
+#include "pf_rvv_double.h"
 
 #ifndef SIMD_SZ
 #  if !defined(PFFFT_SIMD_DISABLE)

--- a/src/simd/pf_float.h
+++ b/src/simd/pf_float.h
@@ -62,6 +62,7 @@ typedef float vsfscalar;
 #include "pf_sse1_float.h"
 #include "pf_neon_float.h"
 #include "pf_altivec_float.h"
+#include "pf_rvv_float.h"
 
 #ifndef SIMD_SZ
 #  if !defined(PFFFT_SIMD_DISABLE)

--- a/src/simd/pf_rvv_double.h
+++ b/src/simd/pf_rvv_double.h
@@ -1,0 +1,121 @@
+
+/* Copyright (c) 2026  Michael Neuling ( mikey@neuling.org )
+
+   Redistribution and use of the Software in source and binary forms,
+   with or without modification, is permitted provided that the
+   following conditions are met:
+
+   - Neither the names of NCAR's Computational and Information Systems
+   Laboratory, the University Corporation for Atmospheric Research,
+   nor the names of its sponsors or contributors may be used to
+   endorse or promote products derived from this Software without
+   specific prior written permission.
+
+   - Redistributions of source code must retain the above copyright
+   notices, this list of conditions, and the disclaimer below.
+
+   - Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions, and the disclaimer below in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   THIS SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+   SOFTWARE.
+*/
+
+#ifndef PF_RVV_DBL_H
+#define PF_RVV_DBL_H
+
+/*
+  RISC-V Vector (RVV 1.0) support macros for double precision.
+
+  pffft hard-codes SIMD_SZ=4 for double precision, matching AVX 256-bit
+  vectors. We use 256-bit fixed-length vectors via GCC's vector_size
+  attribute. The compiler lowers these to RVV instructions with VL=4,
+  e64, m1 — which works for any VLEN >= 256, including the common
+  VLEN=256 found on the Spacemit X-class and similar cores.
+*/
+#if !defined(SIMD_SZ) && !defined(PFFFT_SIMD_DISABLE) && defined(PFFFT_ENABLE_RVV) && defined(__riscv_vector) && (__riscv_v_elen >= 64)
+#pragma message( __FILE__ ": RISC-V Vector (RVV) double macros are defined" )
+
+typedef double   v4sf __attribute__((vector_size(32), aligned(8)));
+typedef long int v4si __attribute__((vector_size(32), aligned(8)));
+
+#  define SIMD_SZ 4
+
+typedef union v4sf_union {
+  v4sf   v;
+  double f[SIMD_SZ];
+} v4sf_union;
+
+/* Both clang and recent GCC accept __builtin_shufflevector; older GCC
+ * only ships __builtin_shuffle. Pick whichever is available. */
+#if defined(__has_builtin) && __has_builtin(__builtin_shufflevector)
+#  define PF_RVV_SHUF4(a, b, i0, i1, i2, i3) \
+     __builtin_shufflevector((a), (b), i0, i1, i2, i3)
+#else
+#  define PF_RVV_SHUF4(a, b, i0, i1, i2, i3) \
+     __builtin_shuffle((a), (b), (v4si){i0, i1, i2, i3})
+#endif
+
+#  define VARCH "RVV"
+#  define VREQUIRES_ALIGN 0
+#  define VZERO()       ((v4sf){0.0, 0.0, 0.0, 0.0})
+#  define VMUL(a,b)     ((a) * (b))
+#  define VADD(a,b)     ((a) + (b))
+#  define VSUB(a,b)     ((a) - (b))
+#  define VMADD(a,b,c)  ((a) * (b) + (c))
+#  define LD_PS1(p)     ((v4sf){(p), (p), (p), (p)})
+#  define VLOAD_UNALIGNED(ptr)  (*(const v4sf *)(ptr))
+#  define VLOAD_ALIGNED(ptr)    (*(const v4sf *)(ptr))
+
+/* INTERLEAVE2: {a0,a1,a2,a3},{b0,b1,b2,b3} -> {a0,b0,a1,b1},{a2,b2,a3,b3} */
+#  define INTERLEAVE2(in1, in2, out1, out2) do {                        \
+    v4sf in1__ = (in1), in2__ = (in2);                                  \
+    out1 = PF_RVV_SHUF4(in1__, in2__, 0, 4, 1, 5);                      \
+    out2 = PF_RVV_SHUF4(in1__, in2__, 2, 6, 3, 7);                      \
+  } while (0)
+
+/* UNINTERLEAVE2: {a0,a1,a2,a3},{b0,b1,b2,b3} -> {a0,a2,b0,b2},{a1,a3,b1,b3} */
+#  define UNINTERLEAVE2(in1, in2, out1, out2) do {                      \
+    v4sf in1__ = (in1), in2__ = (in2);                                  \
+    out1 = PF_RVV_SHUF4(in1__, in2__, 0, 2, 4, 6);                      \
+    out2 = PF_RVV_SHUF4(in1__, in2__, 1, 3, 5, 7);                      \
+  } while (0)
+
+#  define VTRANSPOSE4(x0, x1, x2, x3) do {                              \
+    v4sf r0__ = (x0), r1__ = (x1), r2__ = (x2), r3__ = (x3);            \
+    v4sf t0__ = PF_RVV_SHUF4(r0__, r1__, 0, 4, 1, 5);                   \
+    v4sf t1__ = PF_RVV_SHUF4(r0__, r1__, 2, 6, 3, 7);                   \
+    v4sf t2__ = PF_RVV_SHUF4(r2__, r3__, 0, 4, 1, 5);                   \
+    v4sf t3__ = PF_RVV_SHUF4(r2__, r3__, 2, 6, 3, 7);                   \
+    x0 = PF_RVV_SHUF4(t0__, t2__, 0, 1, 4, 5);                          \
+    x1 = PF_RVV_SHUF4(t0__, t2__, 2, 3, 6, 7);                          \
+    x2 = PF_RVV_SHUF4(t1__, t3__, 0, 1, 4, 5);                          \
+    x3 = PF_RVV_SHUF4(t1__, t3__, 2, 3, 6, 7);                          \
+  } while (0)
+
+/* VSWAPHL(a,b) -> {b0, b1, a2, a3} */
+#  define VSWAPHL(a, b)  PF_RVV_SHUF4((b), (a), 0, 1, 6, 7)
+
+/* reverse/flip all doubles */
+#  define VREV_S(a)      PF_RVV_SHUF4((a), (a), 3, 2, 1, 0)
+/* reverse/flip complex doubles */
+#  define VREV_C(a)      PF_RVV_SHUF4((a), (a), 2, 3, 0, 1)
+
+/* Both load paths happen to be safe for any 8-byte aligned pointer
+ * (the typedef requests only aligned(8)). We still report v4sf-sized
+ * alignment here so the --test-simd self-test sees a mix of aligned
+ * and unaligned addresses, matching the SSE2/AVX double convention. */
+#  define VALIGNED(ptr) ((((uintptr_t)(ptr)) & 0x1F) == 0)
+
+#endif
+
+#endif /* PF_RVV_DBL_H */

--- a/src/simd/pf_rvv_float.h
+++ b/src/simd/pf_rvv_float.h
@@ -1,0 +1,120 @@
+
+/* Copyright (c) 2026  Michael Neuling ( mikey@neuling.org )
+
+   Redistribution and use of the Software in source and binary forms,
+   with or without modification, is permitted provided that the
+   following conditions are met:
+
+   - Neither the names of NCAR's Computational and Information Systems
+   Laboratory, the University Corporation for Atmospheric Research,
+   nor the names of its sponsors or contributors may be used to
+   endorse or promote products derived from this Software without
+   specific prior written permission.
+
+   - Redistributions of source code must retain the above copyright
+   notices, this list of conditions, and the disclaimer below.
+
+   - Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions, and the disclaimer below in the
+   documentation and/or other materials provided with the
+   distribution.
+
+   THIS SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+   NONINFRINGEMENT. IN NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, INDIRECT, INCIDENTAL, SPECIAL,
+   EXEMPLARY, OR CONSEQUENTIAL DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+   SOFTWARE.
+*/
+
+#ifndef PF_RVV_FLT_H
+#define PF_RVV_FLT_H
+
+/*
+  RISC-V Vector (RVV 1.0) support macros.
+
+  pffft hard-codes SIMD_SZ=4 for single precision, so we use 128-bit
+  fixed-length vectors via GCC's vector_size attribute. The compiler
+  lowers these to RVV instructions (vfadd.vv/vfmul.vv/vfmadd.vv/...)
+  with VL=4, e32, m1 — which works for any VLEN >= 128.
+*/
+#if !defined(SIMD_SZ) && !defined(PFFFT_SIMD_DISABLE) && defined(PFFFT_ENABLE_RVV) && defined(__riscv_vector)
+#pragma message( __FILE__ ": RISC-V Vector (RVV) float macros are defined" )
+
+typedef float v4sf __attribute__((vector_size(16), aligned(4)));
+typedef int   v4si __attribute__((vector_size(16), aligned(4)));
+
+#  define SIMD_SZ 4
+
+typedef union v4sf_union {
+  v4sf  v;
+  float f[SIMD_SZ];
+} v4sf_union;
+
+/* Both clang and recent GCC accept __builtin_shufflevector; older GCC
+ * only ships __builtin_shuffle. Pick whichever is available. */
+#if defined(__has_builtin) && __has_builtin(__builtin_shufflevector)
+#  define PF_RVV_SHUF4(a, b, i0, i1, i2, i3) \
+     __builtin_shufflevector((a), (b), i0, i1, i2, i3)
+#else
+#  define PF_RVV_SHUF4(a, b, i0, i1, i2, i3) \
+     __builtin_shuffle((a), (b), (v4si){i0, i1, i2, i3})
+#endif
+
+#  define VARCH "RVV"
+#  define VREQUIRES_ALIGN 0
+#  define VZERO()       ((v4sf){0.f, 0.f, 0.f, 0.f})
+#  define VMUL(a,b)     ((a) * (b))
+#  define VADD(a,b)     ((a) + (b))
+#  define VSUB(a,b)     ((a) - (b))
+#  define VMADD(a,b,c)  ((a) * (b) + (c))
+#  define LD_PS1(p)     ((v4sf){(p), (p), (p), (p)})
+#  define VLOAD_UNALIGNED(ptr)  (*(const v4sf *)(ptr))
+#  define VLOAD_ALIGNED(ptr)    (*(const v4sf *)(ptr))
+
+/* INTERLEAVE2: {a0,a1,a2,a3},{b0,b1,b2,b3} -> {a0,b0,a1,b1},{a2,b2,a3,b3} */
+#  define INTERLEAVE2(in1, in2, out1, out2) do {                        \
+    v4sf in1__ = (in1), in2__ = (in2);                                  \
+    out1 = PF_RVV_SHUF4(in1__, in2__, 0, 4, 1, 5);                      \
+    out2 = PF_RVV_SHUF4(in1__, in2__, 2, 6, 3, 7);                      \
+  } while (0)
+
+/* UNINTERLEAVE2: {a0,a1,a2,a3},{b0,b1,b2,b3} -> {a0,a2,b0,b2},{a1,a3,b1,b3} */
+#  define UNINTERLEAVE2(in1, in2, out1, out2) do {                      \
+    v4sf in1__ = (in1), in2__ = (in2);                                  \
+    out1 = PF_RVV_SHUF4(in1__, in2__, 0, 2, 4, 6);                      \
+    out2 = PF_RVV_SHUF4(in1__, in2__, 1, 3, 5, 7);                      \
+  } while (0)
+
+#  define VTRANSPOSE4(x0, x1, x2, x3) do {                              \
+    v4sf r0__ = (x0), r1__ = (x1), r2__ = (x2), r3__ = (x3);            \
+    v4sf t0__ = PF_RVV_SHUF4(r0__, r1__, 0, 4, 1, 5);                   \
+    v4sf t1__ = PF_RVV_SHUF4(r0__, r1__, 2, 6, 3, 7);                   \
+    v4sf t2__ = PF_RVV_SHUF4(r2__, r3__, 0, 4, 1, 5);                   \
+    v4sf t3__ = PF_RVV_SHUF4(r2__, r3__, 2, 6, 3, 7);                   \
+    x0 = PF_RVV_SHUF4(t0__, t2__, 0, 1, 4, 5);                          \
+    x1 = PF_RVV_SHUF4(t0__, t2__, 2, 3, 6, 7);                          \
+    x2 = PF_RVV_SHUF4(t1__, t3__, 0, 1, 4, 5);                          \
+    x3 = PF_RVV_SHUF4(t1__, t3__, 2, 3, 6, 7);                          \
+  } while (0)
+
+/* VSWAPHL(a,b) -> {b0, b1, a2, a3} */
+#  define VSWAPHL(a, b)  PF_RVV_SHUF4((b), (a), 0, 1, 6, 7)
+
+/* reverse/flip all floats */
+#  define VREV_S(a)      PF_RVV_SHUF4((a), (a), 3, 2, 1, 0)
+/* reverse/flip complex floats (swap the two pairs) */
+#  define VREV_C(a)      PF_RVV_SHUF4((a), (a), 2, 3, 0, 1)
+
+/* Both load paths happen to be safe for any 4-byte aligned pointer
+ * (the typedef requests only aligned(4)). We still report v4sf-sized
+ * alignment here so the --test-simd self-test sees a mix of aligned
+ * and unaligned addresses, matching the SSE/AVX convention. */
+#  define VALIGNED(ptr) ((((uintptr_t)(ptr)) & 0xF) == 0)
+
+#endif
+
+#endif /* PF_RVV_FLT_H */


### PR DESCRIPTION
Adds a RISC-V Vector backend alongside the existing SSE/AVX/NEON/Altivec
paths, gated entirely on `__riscv_vector` + a new `PFFFT_ENABLE_RVV`
build define so the change is a no-op for every other target.

Two commits:
1. `Add RISC-V Vector (RVV 1.0) SIMD backend` — new `src/simd/pf_rvv_float.h`
   and `pf_rvv_double.h`, plus the matching include lines in
   `pf_float.h` / `pf_double.h`, the `SIMD_*_HDRS` listing in
   `CMakeLists.txt`, and a short README mention.
2. `cmake: detect riscv64 and auto-enable RVV (+ CI job)` — mirrors the
   aarch64/NEON auto-enable in `cmake/target_optimizations.cmake`, plus a
   new `build_riscv64_qemu` workflow that exercises the headers under
   `qemu-user-static`.

### Design

- `v4sf` is a GCC `vector_size` typedef (16 bytes for float, 32 for
  double), which the compiler lowers to RVV instructions (`vfadd.vv`
  / `vfmul.vv` / `vfmadd.vv` / `vrgather.vv` / …).
- For float, SIMD_SZ=4 → 128-bit vector, works on any VLEN ≥ 128.
- For double, SIMD_SZ=4 → 256-bit vector, matching the AVX double
  layout. On hardware with VLEN ≥ 256 this is a single instruction;
  otherwise the compiler splits it into two ops. The build detects
  the host VLEN via a tiny `try_run` probe and appends a `zvlNNNb`
  token so the single-instruction form is used when available.
- Shuffles route through a `PF_RVV_SHUF4` helper that picks
  `__builtin_shufflevector` (clang, GCC 12+) or `__builtin_shuffle`
  (older GCC), matching the same pattern used in `src/sse2neon.h`.
- The auto-detect also probes for the V extension itself: if it isn't
  present, the build falls back to plain `rv64gc` (no
  `PFFFT_ENABLE_RVV`, scalar path) instead of producing a binary that
  SIGILLs.

### Verification

Tested on a SpaceMIT X100 (8 cores, VLEN=256, Ubuntu 26.04):

- gcc 15.2.0: `ctest` 13/13 pass; both `test_pffft_{float,double}
  --test-simd` exit clean (the shuffle/transpose self-tests).
- clang 21.1.8: same — `ctest` 13/13, both `--test-simd` pass.
  RVV throughput trails gcc by ~10–25 % (clang's shuffle lowering
  is less tight) but stays solidly above the scalar baseline.
- Auto-detect picks `-march=rv64gcv_zvl256b` and defines
  `PFFFT_ENABLE_RVV`; runtime `pffft_simd_arch()` reports `"RVV"`,
  `pffft_simd_size()` reports `4`.
- Explicit `TARGET_C_ARCH=rv64gc` builds cleanly and runs the scalar
  path — no spurious RVV define.

Performance vs the pure-scalar build
(`-DPFFFT_USE_SIMD=OFF -DPFFFT_USE_SCALAR_VECT=OFF`), real FFT,
`PFFFT-U` column, gcc 15.2, single core (`taskset -c 0`):

| size  | float speedup | double speedup |
|------:|--------------:|---------------:|
|   128 | 2.96×         | 2.05×          |
|   512 | 2.67×         | 2.32×          |
|  1024 | 2.78×         | 2.17×          |
|  4096 | 2.95×         | 2.20×          |
| 16384 | 2.62×         | 2.09×          |
| 65536 | 2.60×         | 2.04×          |

Complex FFTs see roughly 1.3–1.4× as expected
(memory-bandwidth bound).

### Deliberately not done

- `SIMD_SZ=4` is hard-coded throughout pffft's pass functions, so
  this backend stays at 4 lanes rather than scaling with VLEN.
  Using LMUL > 1 or a VLEN-agnostic refactor would need changes
  well outside the SIMD headers.
- No runtime CPU detection — `PFFFT_ENABLE_RVV` is decided at
  compile time, the same way `PFFFT_ENABLE_NEON` is.

### What's tested vs not

- ✅ Native gcc 15.2 and clang 21.1.8 builds on real RVV 1.0
  hardware (correctness, `--test-simd`, performance numbers above).
- ✅ Explicit `TARGET_C_ARCH=rv64gc` (no-V) fallback path on the
  same hardware.
- ⚠️ The new `build_riscv64_qemu` CI job has not yet run on
  GitHub Actions; the first push may need toolchain/QEMU
  adjustments.

Happy to iterate on any of this — particularly the CMake glue and
the CI job — if there's a different shape you'd prefer.

Implementation done with Claude Code; see Assisted-by: trailers on the commits.