### PR TITLE
Convolution improvements

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -52,6 +52,14 @@ jobs:
     - name: cmake_make_no-simd_float_double
       run: mkdir build_no-simd_full && cmake -S . -B build_no-simd_full -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPFFFT_USE_SIMD=OFF -DPFFFT_USE_BENCH_GREEN=OFF -DPFFFT_USE_BENCH_KISS=OFF -DPFFFT_USE_BENCH_POCKET=OFF -DTARGET_CXX_ARCH=native -DTARGET_C_ARCH=native  && cmake --build build_no-simd_full
     - name: cmake_make_no-simd_scalar_float_double
+    - name: cmake_make_no-simd_novect_float_double
+      run: mkdir build_no-simd_novect && cmake -S . -B build_no-simd_novect -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPFFFT_USE_SIMD=OFF -DPFFFT_USE_SCALAR_VECT=OFF -DPFFFT_USE_BENCH_GREEN=OFF -DPFFFT_USE_BENCH_KISS=OFF -DPFFFT_USE_BENCH_POCKET=OFF -DTARGET_CXX_ARCH=native -DTARGET_C_ARCH=native && cmake --build build_no-simd_novect
+    - name: ctest_no-simd_novect
+      # greenffts octave wrappers cannot run outside their environment;
+      # everything else -- including the SIMD_SZ==1 nosimd kernels --
+      # must pass. (The harness step-0 loop that used to hang this test
+      # under SZ=1 was fixed in tests/test_fft_factors.c.)
+      run: cd build_no-simd_novect && ctest -E "convTest|conv2dTest|rfft2d" --output-on-failure
       run: mkdir build_no-simd_scalar_full && cmake -S . -B build_no-simd_scalar_full -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPFFFT_USE_SIMD=OFF -DPFFFT_USE_SCALAR_VECT=ON -DPFFFT_USE_BENCH_GREEN=OFF -DPFFFT_USE_BENCH_KISS=OFF -DPFFFT_USE_BENCH_POCKET=OFF -DTARGET_CXX_ARCH=native -DTARGET_C_ARCH=native && cmake --build build_no-simd_scalar_full
     - name: compress
       run: tar zcvf pffft_w_mipp_ubuntu-amd64.tar.gz --exclude=CMakeFiles --exclude=*.cmake --exclude=Makefile --exclude=CMakeCache.txt build_simd_full build_simd_float build_simd_double build_no-simd_full build_no-simd_scalar_full
@@ -75,6 +83,14 @@ jobs:
     - name: cmake_make_no-simd_float_double
       run: mkdir build_no-simd_full && cmake -S . -B build_no-simd_full -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPFFFT_USE_SIMD=OFF -DPFFFT_USE_BENCH_GREEN=OFF -DPFFFT_USE_BENCH_KISS=OFF -DPFFFT_USE_BENCH_POCKET=OFF -DTARGET_CXX_ARCH=native -DTARGET_C_ARCH=native  && cmake --build build_no-simd_full
     - name: cmake_make_no-simd_scalar_float_double
+    - name: cmake_make_no-simd_novect_float_double
+      run: mkdir build_no-simd_novect && cmake -S . -B build_no-simd_novect -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPFFFT_USE_SIMD=OFF -DPFFFT_USE_SCALAR_VECT=OFF -DPFFFT_USE_BENCH_GREEN=OFF -DPFFFT_USE_BENCH_KISS=OFF -DPFFFT_USE_BENCH_POCKET=OFF -DTARGET_CXX_ARCH=native -DTARGET_C_ARCH=native && cmake --build build_no-simd_novect
+    - name: ctest_no-simd_novect
+      # greenffts octave wrappers cannot run outside their environment;
+      # everything else -- including the SIMD_SZ==1 nosimd kernels --
+      # must pass. (The harness step-0 loop that used to hang this test
+      # under SZ=1 was fixed in tests/test_fft_factors.c.)
+      run: cd build_no-simd_novect && ctest -E "convTest|conv2dTest|rfft2d" --output-on-failure
       run: mkdir build_no-simd_scalar_full && cmake -S . -B build_no-simd_scalar_full -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DPFFFT_USE_SIMD=OFF -DPFFFT_USE_SCALAR_VECT=ON -DPFFFT_USE_BENCH_GREEN=OFF -DPFFFT_USE_BENCH_KISS=OFF -DPFFFT_USE_BENCH_POCKET=OFF -DTARGET_CXX_ARCH=native -DTARGET_C_ARCH=native && cmake --build build_no-simd_scalar_full
     - name: compress
       run: tar zcvf pffft_ubuntu-amd64.tar.gz --exclude=CMakeFiles --exclude=*.cmake --exclude=Makefile --exclude=CMakeCache.txt build_simd_full build_simd_float build_simd_double build_no-simd_full build_no-simd_scalar_full

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,5 @@
+{
+  "format_on_save": "off",
+  "hard_tabs": false,
+  "tab_size": 2
+}

--- a/README.md
+++ b/README.md
@@ -251,7 +251,9 @@ The main changes on top of the original include:
 * additional library for fast convolution
 * const-correct setup arguments for all transform functions
 * zero-phase convolution support for linear-phase FIR filters
-  (`pffft_zconvert_zp()` / `pffft_zconvolve_zp()`, see `pffft.h`)
+  (`pffft_zconvert_zp()` / `pffft_zconvolve_zp()`, see `pffft.h`);
+  with default scaling the forward transform -> zconvolve_zp ->
+  backward pipeline yields the circular convolution at unit gain
 * unscaled frequency-domain multiply `pffft_zconvolve()` and `pffft_zconvolve_scale()`
 * cmake support
 * ctest

--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ The main changes on top of the original include:
 * c++ headers (wrapper)
 * additional API helper functions
 * additional library for fast convolution
+* const-correct setup arguments for all transform functions
+* zero-phase convolution support for linear-phase FIR filters
+  (`pffft_zconvert_zp()` / `pffft_zconvolve_zp()`, see `pffft.h`)
+* unscaled frequency-domain multiply `pffft_zconvolve()` and `pffft_zconvolve_scale()`
 * cmake support
 * ctest
 

--- a/benchmarks/bench_pffft.c
+++ b/benchmarks/bench_pffft.c
@@ -398,8 +398,7 @@ int pffft_validate_N(int N, int cplx) {
       float conv_err = 0, conv_max = 0;
 
       PFFFT_FUNC(zreorder)(s, ref, tmp, PFFFT_FORWARD);
-      memset(out, 0, Nbytes);
-      PFFFT_FUNC(zconvolve_accumulate)(s, ref, ref, out, 1.0);
+      PFFFT_FUNC(zconvolve)(s, ref, ref, out);
       PFFFT_FUNC(zreorder)(s, out, tmp2, PFFFT_FORWARD);
       
       for (k=0; k < Nfloat; k += 2) {

--- a/include/pffft/pffft.h
+++ b/include/pffft/pffft.h
@@ -232,6 +232,40 @@ extern "C" {
      The dft_a, dft_b and dft_ab pointers may alias.
   */
   PFFFT_EXPORT void pffft_zconvolve(const PFFFT_Setup *setup, const float *dft_a, const float *dft_b, float *dft_ab);
+  
+  /*
+     Convert an unordered PFFFT_REAL forward-transform result (as
+     produced by pffft_transform(.., PFFFT_FORWARD)) into "zero-phase"
+     form: imaginary vector lanes are zeroed, real lanes are multiplied
+     by 'scaling'. Useful for linear-phase FIR filters whose impulse
+     response is centered at t = 0 with the left-hand taps wrapped
+     around to the end of the transform block: their spectrum has no
+     imaginary components. 'in' may alias 'out'.
+
+     Layout caveat: the unordered REAL layout packs the two real-valued
+     boundary coefficients F(0) and F(N/2) into the first lanes of the
+     first two vectors, where F(N/2) occupies an otherwise-imaginary
+     lane. pffft_zconvert_zp() keeps that lane (scaled), so the output
+     is NOT a plain spectrum: multiply it only with pffft_zconvolve_zp(),
+     never with pffft_zconvolve_scale() or pffft_zconvolve(), which
+     would cross-multiply the DC and Nyquist lanes.
+
+     Returns 0 on success, nonzero if setup was not created for
+     PFFFT_REAL.
+  */
+  PFFFT_EXPORT int pffft_zconvert_zp(const PFFFT_Setup *setup, const float *in, float *out, float scaling);
+
+  /*
+     Frequency-domain multiply of an unordered PFFFT_REAL forward
+     spectrum dft_x with a zero-phase filter spectrum dft_hzp produced
+     by pffft_zconvert_zp(): dft_ab = dft_x * dft_hzp. No accumulation,
+     no scaling -- scale the static filter at conversion time instead.
+     All pointers may alias.
+
+     Returns 0 on success, nonzero if setup was not created for
+     PFFFT_REAL.
+  */
+  PFFFT_EXPORT int pffft_zconvolve_zp(const PFFFT_Setup *setup, const float *dft_x, const float *dft_hzp, float *dft_ab);
 
   /*
      deprecated synonym for pffft_zconvolve_scale()

--- a/include/pffft/pffft.h
+++ b/include/pffft/pffft.h
@@ -95,6 +95,16 @@
   #endif
 #endif
 
+#ifndef PFFFT_DEPRECATED
+  #if defined(__GNUC__) || defined(__clang__)
+    #define PFFFT_DEPRECATED __attribute__((deprecated))
+  #elif defined(_MSC_VER)
+    #define PFFFT_DEPRECATED __declspec(deprecated)
+  #else
+    #define PFFFT_DEPRECATED
+  #endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -207,7 +217,12 @@ extern "C" {
 
      The dft_a, dft_b and dft_ab pointers may alias.
   */
-  PFFFT_EXPORT void pffft_zconvolve_no_accu(const PFFFT_Setup *setup, const float *dft_a, const float *dft_b, float *dft_ab, float scaling);
+  PFFFT_EXPORT void pffft_zconvolve_scale(const PFFFT_Setup *setup, const float *dft_a, const float *dft_b, float *dft_ab, float scaling);
+
+  /*
+     deprecated synonym for pffft_zconvolve_scale()
+  */
+  PFFFT_EXPORT void PFFFT_DEPRECATED pffft_zconvolve_no_accu(const PFFFT_Setup *setup, const float *dft_a, const float *dft_b, float *dft_ab, float scaling);
 
   /* return 4 or 1 wether support SSE/NEON/Altivec instructions was enabled when building pffft.c */
   PFFFT_EXPORT int pffft_simd_size(void);

--- a/include/pffft/pffft.h
+++ b/include/pffft/pffft.h
@@ -237,10 +237,15 @@ extern "C" {
      Convert an unordered PFFFT_REAL forward-transform result (as
      produced by pffft_transform(.., PFFFT_FORWARD)) into "zero-phase"
      form: imaginary vector lanes are zeroed, real lanes are multiplied
-     by 'scaling'. Useful for linear-phase FIR filters whose impulse
-     response is centered at t = 0 with the left-hand taps wrapped
-     around to the end of the transform block: their spectrum has no
-     imaginary components. 'in' may alias 'out'.
+     by 'scaling' and normalized by 1/N. Useful for linear-phase FIR
+     filters whose impulse response is centered at t = 0 with the
+     left-hand taps wrapped around to the end of the transform block:
+     their spectrum has no imaginary components. 'in' may alias 'out'.
+
+     With scaling == 1 the pipeline transform(x, FORWARD) ->
+     pffft_zconvolve_zp() -> transform(.., BACKWARD) yields the
+     circular convolution of x with the filter at unit gain.
+     'scaling' specifies an additional gain on top of that.
 
      Layout caveat: the unordered REAL layout packs the two real-valued
      boundary coefficients F(0) and F(N/2) into the first lanes of the
@@ -258,9 +263,11 @@ extern "C" {
   /*
      Frequency-domain multiply of an unordered PFFFT_REAL forward
      spectrum dft_x with a zero-phase filter spectrum dft_hzp produced
-     by pffft_zconvert_zp(): dft_ab = dft_x * dft_hzp. No accumulation,
-     no scaling -- scale the static filter at conversion time instead.
-     All pointers may alias.
+     by pffft_zconvert_zp(): dft_ab = dft_x * dft_hzp. No accumulation.
+     With a filter converted using scaling == 1, the pipeline
+     transform(x, FORWARD) -> zconvolve_zp() -> transform(.., BACKWARD)
+     yields the circular convolution at unit gain. All pointers may
+     alias.
 
      Returns 0 on success, nonzero if setup was not created for
      PFFFT_REAL.

--- a/include/pffft/pffft.h
+++ b/include/pffft/pffft.h
@@ -156,7 +156,7 @@ extern "C" {
 
      input and output may alias.
   */
-  PFFFT_EXPORT void pffft_transform(PFFFT_Setup *setup, const float *input, float *output, float *work, pffft_direction_t direction);
+  PFFFT_EXPORT void pffft_transform(const PFFFT_Setup *setup, const float *input, float *output, float *work, pffft_direction_t direction);
 
   /* 
      Similar to pffft_transform, but makes sure that the output is
@@ -165,7 +165,7 @@ extern "C" {
      
      input and output may alias.
   */
-  PFFFT_EXPORT void pffft_transform_ordered(PFFFT_Setup *setup, const float *input, float *output, float *work, pffft_direction_t direction);
+  PFFFT_EXPORT void pffft_transform_ordered(const PFFFT_Setup *setup, const float *input, float *output, float *work, pffft_direction_t direction);
 
   /* 
      call pffft_zreorder(.., PFFFT_FORWARD) after pffft_transform(...,
@@ -179,7 +179,7 @@ extern "C" {
      
      input and output should not alias.
   */
-  PFFFT_EXPORT void pffft_zreorder(PFFFT_Setup *setup, const float *input, float *output, pffft_direction_t direction);
+  PFFFT_EXPORT void pffft_zreorder(const PFFFT_Setup *setup, const float *input, float *output, pffft_direction_t direction);
 
   /* 
      Perform a multiplication of the frequency components of dft_a and
@@ -193,7 +193,7 @@ extern "C" {
      
      The dft_a, dft_b and dft_ab pointers may alias.
   */
-  PFFFT_EXPORT void pffft_zconvolve_accumulate(PFFFT_Setup *setup, const float *dft_a, const float *dft_b, float *dft_ab, float scaling);
+  PFFFT_EXPORT void pffft_zconvolve_accumulate(const PFFFT_Setup *setup, const float *dft_a, const float *dft_b, float *dft_ab, float scaling);
 
   /* 
      Perform a multiplication of the frequency components of dft_a and
@@ -207,7 +207,7 @@ extern "C" {
 
      The dft_a, dft_b and dft_ab pointers may alias.
   */
-  PFFFT_EXPORT void pffft_zconvolve_no_accu(PFFFT_Setup *setup, const float *dft_a, const float *dft_b, float *dft_ab, float scaling);
+  PFFFT_EXPORT void pffft_zconvolve_no_accu(const PFFFT_Setup *setup, const float *dft_a, const float *dft_b, float *dft_ab, float scaling);
 
   /* return 4 or 1 wether support SSE/NEON/Altivec instructions was enabled when building pffft.c */
   PFFFT_EXPORT int pffft_simd_size(void);

--- a/include/pffft/pffft.h
+++ b/include/pffft/pffft.h
@@ -218,6 +218,20 @@ extern "C" {
      The dft_a, dft_b and dft_ab pointers may alias.
   */
   PFFFT_EXPORT void pffft_zconvolve_scale(const PFFFT_Setup *setup, const float *dft_a, const float *dft_b, float *dft_ab, float scaling);
+  
+  /*
+     Perform a multiplication of the frequency components of dft_a and
+     dft_b and put result in dft_ab, without accumulation and without
+     scaling. The arrays should have been obtained with
+     pffft_transform(.., PFFFT_FORWARD) and should *not* have been
+     reordered with pffft_zreorder (otherwise just perform the operation
+     yourself as the dft coefs are stored as interleaved complex numbers).
+
+     the operation performed is: dft_ab = dft_a * dft_b
+
+     The dft_a, dft_b and dft_ab pointers may alias.
+  */
+  PFFFT_EXPORT void pffft_zconvolve(const PFFFT_Setup *setup, const float *dft_a, const float *dft_b, float *dft_ab);
 
   /*
      deprecated synonym for pffft_zconvolve_scale()

--- a/include/pffft/pffft.hpp
+++ b/include/pffft/pffft.hpp
@@ -336,6 +336,20 @@ public:
           AlignedVector<Scalar> & spectrum_internal_ab,
           const Scalar scaling );
 
+  // unscaled variant of the above
+  AlignedVector<Scalar> & convolve(
+          const AlignedVector<Scalar> & spectrum_internal_a,
+          const AlignedVector<Scalar> & spectrum_internal_b,
+          AlignedVector<Scalar> & spectrum_internal_ab );
+
+  int zconvertZP(const AlignedVector<Scalar> & spectrum_internal_in,
+                 AlignedVector<Scalar> & spectrum_internal_out,
+                 const Scalar scaling );
+
+  int convolveZP(const AlignedVector<Scalar> & spectrum_internal_x,
+                 const AlignedVector<Scalar> & spectrum_internal_hzp,
+                 AlignedVector<Scalar> & spectrum_internal_ab );
+
 
   ////////////////////////////////////////////
   ////
@@ -380,6 +394,22 @@ public:
                    const Scalar* spectrum_internal_b,
                    Scalar* spectrum_internal_ab,
                    const Scalar scaling);
+
+  // unscaled variant of the above: spectrum_internal_ab = a * b
+  Scalar* convolve(const Scalar* spectrum_internal_a,
+                   const Scalar* spectrum_internal_b,
+                   Scalar* spectrum_internal_ab);
+
+  // zero-phase helpers for REAL transforms; return 0 on success,
+  // nonzero for COMPLEX transforms. See pffft_zconvert_zp() /
+  // pffft_zconvolve_zp() for the layout contract.
+  int zconvertZP(const Scalar* spectrum_internal_in,
+                 Scalar* spectrum_internal_out,
+                 const Scalar scaling);
+
+  int convolveZP(const Scalar* spectrum_internal_x,
+                 const Scalar* spectrum_internal_hzp,
+                 Scalar* spectrum_internal_ab);
 
   Scalar* convolveAccumulate(const Scalar* spectrum_internal_a,
                              const Scalar* spectrum_internal_b,
@@ -495,6 +525,18 @@ public:
   {
     pffft_zconvolve(self, dft_a, dft_b, dft_ab);
   }
+
+  int zconvertZP(const Scalar* in, Scalar* out, const Scalar scaling)
+  {
+    return pffft_zconvert_zp(self, in, out, scaling);
+  }
+
+  int convolveZP(const Scalar* dft_x,
+                 const Scalar* dft_hzp,
+                 Scalar* dft_ab)
+  {
+    return pffft_zconvolve_zp(self, dft_x, dft_hzp, dft_ab);
+  }
 };
 
 
@@ -557,6 +599,18 @@ public:
                 Scalar* dft_ab)
   {
     pffft_zconvolve(self, dft_a, dft_b, dft_ab);
+  }
+
+  int zconvertZP(const Scalar* in, Scalar* out, const Scalar scaling)
+  {
+    return pffft_zconvert_zp(self, in, out, scaling);
+  }
+
+  int convolveZP(const Scalar* dft_x,
+                 const Scalar* dft_hzp,
+                 Scalar* dft_ab)
+  {
+    return pffft_zconvolve_zp(self, dft_x, dft_hzp, dft_ab);
   }
 };
 
@@ -636,6 +690,17 @@ public:
   {
     pffftd_zconvolve(self, dft_a, dft_b, dft_ab);
   }
+  int zconvertZP(const Scalar* in, Scalar* out, const Scalar scaling)
+  {
+    return pffftd_zconvert_zp(self, in, out, scaling);
+  }
+
+  int convolveZP(const Scalar* dft_x,
+                 const Scalar* dft_hzp,
+                 Scalar* dft_ab)
+  {
+    return pffftd_zconvolve_zp(self, dft_x, dft_hzp, dft_ab);
+  }
 };
 
 template<>
@@ -705,6 +770,17 @@ public:
                 Scalar* dft_ab)
   {
     pffftd_zconvolve(self, dft_a, dft_b, dft_ab);
+  }
+  int zconvertZP(const Scalar* in, Scalar* out, const Scalar scaling)
+  {
+    return pffftd_zconvert_zp(self, in, out, scaling);
+  }
+
+  int convolveZP(const Scalar* dft_x,
+                 const Scalar* dft_hzp,
+                 Scalar* dft_ab)
+  {
+    return pffftd_zconvolve_zp(self, dft_x, dft_hzp, dft_ab);
   }
 };
 
@@ -870,6 +946,41 @@ Fft<T>::convolve(
   return spectrum_internal_ab;
 }
 
+template<typename T>
+inline AlignedVector< typename Fft<T>::Scalar > &
+Fft<T>::convolve(
+    const AlignedVector<Scalar> & spectrum_internal_a,
+    const AlignedVector<Scalar> & spectrum_internal_b,
+    AlignedVector<Scalar> & spectrum_internal_ab )
+{
+  convolve( spectrum_internal_a.data(), spectrum_internal_b.data(),
+            spectrum_internal_ab.data() );
+  return spectrum_internal_ab;
+}
+
+template<typename T>
+inline int
+Fft<T>::zconvertZP(
+    const AlignedVector<Scalar> & spectrum_internal_in,
+    AlignedVector<Scalar> & spectrum_internal_out,
+    const Scalar scaling )
+{
+  return zconvertZP( spectrum_internal_in.data(),
+                     spectrum_internal_out.data(), scaling );
+}
+
+template<typename T>
+inline int
+Fft<T>::convolveZP(
+    const AlignedVector<Scalar> & spectrum_internal_x,
+    const AlignedVector<Scalar> & spectrum_internal_hzp,
+    AlignedVector<Scalar> & spectrum_internal_ab )
+{
+  return convolveZP( spectrum_internal_x.data(),
+                     spectrum_internal_hzp.data(),
+                     spectrum_internal_ab.data() );
+}
+
 
 template<typename T>
 inline typename Fft<T>::Complex *
@@ -949,6 +1060,37 @@ Fft<T>::convolve(const Scalar* dft_a,
   assert(isValid());
   setup.convolve(dft_a, dft_b, dft_ab, scaling);
   return dft_ab;
+}
+
+template<typename T>
+inline typename pffft::Fft<T>::Scalar*
+Fft<T>::convolve(const Scalar* dft_a,
+                 const Scalar* dft_b,
+                 Scalar* dft_ab)
+{
+  assert(isValid());
+  setup.convolve(dft_a, dft_b, dft_ab);
+  return dft_ab;
+}
+
+template<typename T>
+inline int
+Fft<T>::zconvertZP(const Scalar* spectrum_internal_in,
+                   Scalar* spectrum_internal_out,
+                   const Scalar scaling)
+{
+  assert(isValid());
+  return setup.zconvertZP(spectrum_internal_in, spectrum_internal_out, scaling);
+}
+
+template<typename T>
+inline int
+Fft<T>::convolveZP(const Scalar* dft_x,
+                   const Scalar* dft_hzp,
+                   Scalar* dft_ab)
+{
+  assert(isValid());
+  return setup.convolveZP(dft_x, dft_hzp, dft_ab);
 }
 
 template<typename T>

--- a/include/pffft/pffft.hpp
+++ b/include/pffft/pffft.hpp
@@ -486,7 +486,7 @@ public:
                 Scalar* dft_ab,
                 const Scalar scaling)
   {
-    pffft_zconvolve_no_accu(self, dft_a, dft_b, dft_ab, scaling);
+    pffft_zconvolve_scale(self, dft_a, dft_b, dft_ab, scaling);
   }
 };
 
@@ -542,7 +542,7 @@ public:
                 Scalar* dft_ab,
                 const Scalar scaling)
   {
-    pffft_zconvolve_no_accu(self, dft_a, dft_b, dft_ab, scaling);
+    pffft_zconvolve_scale(self, dft_a, dft_b, dft_ab, scaling);
   }
 };
 
@@ -613,7 +613,7 @@ public:
                 Scalar* dft_ab,
                 const Scalar scaling)
   {
-    pffftd_zconvolve_no_accu(self, dft_a, dft_b, dft_ab, scaling);
+    pffftd_zconvolve_scale(self, dft_a, dft_b, dft_ab, scaling);
   }
 };
 
@@ -676,7 +676,7 @@ public:
                 Scalar* dft_ab,
                 const Scalar scaling)
   {
-    pffftd_zconvolve_no_accu(self, dft_a, dft_b, dft_ab, scaling);
+    pffftd_zconvolve_scale(self, dft_a, dft_b, dft_ab, scaling);
   }
 };
 

--- a/include/pffft/pffft.hpp
+++ b/include/pffft/pffft.hpp
@@ -401,7 +401,10 @@ public:
                    Scalar* spectrum_internal_ab);
 
   // zero-phase helpers for REAL transforms; return 0 on success,
-  // nonzero for COMPLEX transforms. See pffft_zconvert_zp() /
+  // nonzero for COMPLEX transforms. zconvertZP() normalizes by 1/N:
+  // with scaling == 1, transform(x, FORWARD) -> convolveZP() ->
+  // transform(.., BACKWARD) yields the circular convolution of x
+  // with the filter at unit gain. See pffft_zconvert_zp() /
   // pffft_zconvolve_zp() for the layout contract.
   int zconvertZP(const Scalar* spectrum_internal_in,
                  Scalar* spectrum_internal_out,

--- a/include/pffft/pffft.hpp
+++ b/include/pffft/pffft.hpp
@@ -488,6 +488,13 @@ public:
   {
     pffft_zconvolve_scale(self, dft_a, dft_b, dft_ab, scaling);
   }
+
+  void convolve(const Scalar* dft_a,
+                const Scalar* dft_b,
+                Scalar* dft_ab)
+  {
+    pffft_zconvolve(self, dft_a, dft_b, dft_ab);
+  }
 };
 
 
@@ -543,6 +550,13 @@ public:
                 const Scalar scaling)
   {
     pffft_zconvolve_scale(self, dft_a, dft_b, dft_ab, scaling);
+  }
+
+  void convolve(const Scalar* dft_a,
+                const Scalar* dft_b,
+                Scalar* dft_ab)
+  {
+    pffft_zconvolve(self, dft_a, dft_b, dft_ab);
   }
 };
 
@@ -615,6 +629,13 @@ public:
   {
     pffftd_zconvolve_scale(self, dft_a, dft_b, dft_ab, scaling);
   }
+
+  void convolve(const Scalar* dft_a,
+                const Scalar* dft_b,
+                Scalar* dft_ab)
+  {
+    pffftd_zconvolve(self, dft_a, dft_b, dft_ab);
+  }
 };
 
 template<>
@@ -677,6 +698,13 @@ public:
                 const Scalar scaling)
   {
     pffftd_zconvolve_scale(self, dft_a, dft_b, dft_ab, scaling);
+  }
+
+  void convolve(const Scalar* dft_a,
+                const Scalar* dft_b,
+                Scalar* dft_ab)
+  {
+    pffftd_zconvolve(self, dft_a, dft_b, dft_ab);
   }
 };
 

--- a/include/pffft/pffft_double.h
+++ b/include/pffft/pffft_double.h
@@ -210,6 +210,20 @@ extern "C" {
      The dft_a, dft_b and dft_ab pointers may alias.
   */
   PFFFT_EXPORT void pffftd_zconvolve_scale(const PFFFTD_Setup *setup, const double *dft_a, const double *dft_b, double *dft_ab, double scaling);
+  
+  /*
+     Perform a multiplication of the frequency components of dft_a and
+     dft_b and put result in dft_ab, without accumulation and without
+     scaling. The arrays should have been obtained with
+     pffft_transform(.., PFFFT_FORWARD) and should *not* have been
+     reordered with pffft_zreorder (otherwise just perform the operation
+     yourself as the dft coefs are stored as interleaved complex numbers).
+
+     the operation performed is: dft_ab = dft_a * dft_b
+
+     The dft_a, dft_b and dft_ab pointers may alias.
+  */
+  PFFFT_EXPORT void pffftd_zconvolve(const PFFFTD_Setup *setup, const double *dft_a, const double *dft_b, double *dft_ab);
 
   /*
      deprecated synonym for pffftd_zconvolve_scale()

--- a/include/pffft/pffft_double.h
+++ b/include/pffft/pffft_double.h
@@ -100,6 +100,16 @@
   #endif
 #endif
 
+#ifndef PFFFT_DEPRECATED
+  #if defined(__GNUC__) || defined(__clang__)
+    #define PFFFT_DEPRECATED __attribute__((deprecated))
+  #elif defined(_MSC_VER)
+    #define PFFFT_DEPRECATED __declspec(deprecated)
+  #else
+    #define PFFFT_DEPRECATED
+  #endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -199,7 +209,12 @@ extern "C" {
 
      The dft_a, dft_b and dft_ab pointers may alias.
   */
-  PFFFT_EXPORT void pffftd_zconvolve_no_accu(const PFFFTD_Setup *setup, const double *dft_a, const double *dft_b, double*dft_ab, double scaling);
+  PFFFT_EXPORT void pffftd_zconvolve_scale(const PFFFTD_Setup *setup, const double *dft_a, const double *dft_b, double *dft_ab, double scaling);
+
+  /*
+     deprecated synonym for pffftd_zconvolve_scale()
+  */
+  PFFFT_EXPORT void PFFFT_DEPRECATED pffftd_zconvolve_no_accu(const PFFFTD_Setup *setup, const double *dft_a, const double *dft_b, double *dft_ab, double scaling);
 
   /* return 4 or 1 wether support AVX instructions was enabled when building pffft-double.c */
   PFFFT_EXPORT int pffftd_simd_size();

--- a/include/pffft/pffft_double.h
+++ b/include/pffft/pffft_double.h
@@ -148,7 +148,7 @@ extern "C" {
 
      input and output may alias.
   */
-  PFFFT_EXPORT void pffftd_transform(PFFFTD_Setup *setup, const double *input, double *output, double *work, pffft_direction_t direction);
+  PFFFT_EXPORT void pffftd_transform(const PFFFTD_Setup *setup, const double *input, double *output, double *work, pffft_direction_t direction);
 
   /* 
      Similar to pffft_transform, but makes sure that the output is
@@ -157,7 +157,7 @@ extern "C" {
      
      input and output may alias.
   */
-  PFFFT_EXPORT void pffftd_transform_ordered(PFFFTD_Setup *setup, const double *input, double *output, double *work, pffft_direction_t direction);
+  PFFFT_EXPORT void pffftd_transform_ordered(const PFFFTD_Setup *setup, const double *input, double *output, double *work, pffft_direction_t direction);
 
   /* 
      call pffft_zreorder(.., PFFFT_FORWARD) after pffft_transform(...,
@@ -171,7 +171,7 @@ extern "C" {
      
      input and output should not alias.
   */
-  PFFFT_EXPORT void pffftd_zreorder(PFFFTD_Setup *setup, const double *input, double *output, pffft_direction_t direction);
+  PFFFT_EXPORT void pffftd_zreorder(const PFFFTD_Setup *setup, const double *input, double *output, pffft_direction_t direction);
 
   /* 
      Perform a multiplication of the frequency components of dft_a and
@@ -185,7 +185,7 @@ extern "C" {
      
      The dft_a, dft_b and dft_ab pointers may alias.
   */
-  PFFFT_EXPORT void pffftd_zconvolve_accumulate(PFFFTD_Setup *setup, const double *dft_a, const double *dft_b, double *dft_ab, double scaling);
+  PFFFT_EXPORT void pffftd_zconvolve_accumulate(const PFFFTD_Setup *setup, const double *dft_a, const double *dft_b, double *dft_ab, double scaling);
 
   /* 
      Perform a multiplication of the frequency components of dft_a and
@@ -199,7 +199,7 @@ extern "C" {
 
      The dft_a, dft_b and dft_ab pointers may alias.
   */
-  PFFFT_EXPORT void pffftd_zconvolve_no_accu(PFFFTD_Setup *setup, const double *dft_a, const double *dft_b, double*dft_ab, double scaling);
+  PFFFT_EXPORT void pffftd_zconvolve_no_accu(const PFFFTD_Setup *setup, const double *dft_a, const double *dft_b, double*dft_ab, double scaling);
 
   /* return 4 or 1 wether support AVX instructions was enabled when building pffft-double.c */
   PFFFT_EXPORT int pffftd_simd_size();

--- a/include/pffft/pffft_double.h
+++ b/include/pffft/pffft_double.h
@@ -229,10 +229,15 @@ extern "C" {
      Convert an unordered PFFFT_REAL forward-transform result (as
      produced by pffftd_transform(.., PFFFT_FORWARD)) into "zero-phase"
      form: imaginary vector lanes are zeroed, real lanes are multiplied
-     by 'scaling'. Useful for linear-phase FIR filters whose impulse
-     response is centered at t = 0 with the left-hand taps wrapped
-     around to the end of the transform block: their spectrum has no
-     imaginary components. 'in' may alias 'out'.
+     by 'scaling' and normalized by 1/N. Useful for linear-phase FIR
+     filters whose impulse response is centered at t = 0 with the
+     left-hand taps wrapped around to the end of the transform block:
+     their spectrum has no imaginary components. 'in' may alias 'out'.
+
+     With scaling == 1 the pipeline pffftd_transform(x, FORWARD) ->
+     pffftd_zconvolve_zp() -> pffftd_transform(.., BACKWARD) yields
+     the circular convolution of x with the filter at unit gain.
+     'scaling' specifies an additional gain on top of that.
 
      Layout caveat: the unordered REAL layout packs the two real-valued
      boundary coefficients F(0) and F(N/2) into the first lanes of the
@@ -250,9 +255,11 @@ extern "C" {
   /*
      Frequency-domain multiply of an unordered PFFFT_REAL forward
      spectrum dft_x with a zero-phase filter spectrum dft_hzp produced
-     by pffftd_zconvert_zp(): dft_ab = dft_x * dft_hzp. No accumulation,
-     no scaling -- scale the static filter at conversion time instead.
-     All pointers may alias.
+     by pffftd_zconvert_zp(): dft_ab = dft_x * dft_hzp. No accumulation.
+     With a filter converted using scaling == 1, the pipeline
+     pffftd_transform(x, FORWARD) -> zconvolve_zp() ->
+     pffftd_transform(.., BACKWARD) yields the circular convolution at
+     unit gain. All pointers may alias.
 
      Returns 0 on success, nonzero if setup was not created for
      PFFFT_REAL.

--- a/include/pffft/pffft_double.h
+++ b/include/pffft/pffft_double.h
@@ -226,6 +226,40 @@ extern "C" {
   PFFFT_EXPORT void pffftd_zconvolve(const PFFFTD_Setup *setup, const double *dft_a, const double *dft_b, double *dft_ab);
 
   /*
+     Convert an unordered PFFFT_REAL forward-transform result (as
+     produced by pffftd_transform(.., PFFFT_FORWARD)) into "zero-phase"
+     form: imaginary vector lanes are zeroed, real lanes are multiplied
+     by 'scaling'. Useful for linear-phase FIR filters whose impulse
+     response is centered at t = 0 with the left-hand taps wrapped
+     around to the end of the transform block: their spectrum has no
+     imaginary components. 'in' may alias 'out'.
+
+     Layout caveat: the unordered REAL layout packs the two real-valued
+     boundary coefficients F(0) and F(N/2) into the first lanes of the
+     first two vectors, where F(N/2) occupies an otherwise-imaginary
+     lane. pffftd_zconvert_zp() keeps that lane (scaled), so the output
+     is NOT a plain spectrum: multiply it only with pffftd_zconvolve_zp(),
+     never with pffftd_zconvolve_scale() or pffftd_zconvolve(), which
+     would cross-multiply the DC and Nyquist lanes.
+
+     Returns 0 on success, nonzero if setup was not created for
+     PFFFT_REAL.
+  */
+  PFFFT_EXPORT int pffftd_zconvert_zp(const PFFFTD_Setup *setup, const double *in, double *out, double scaling);
+
+  /*
+     Frequency-domain multiply of an unordered PFFFT_REAL forward
+     spectrum dft_x with a zero-phase filter spectrum dft_hzp produced
+     by pffftd_zconvert_zp(): dft_ab = dft_x * dft_hzp. No accumulation,
+     no scaling -- scale the static filter at conversion time instead.
+     All pointers may alias.
+
+     Returns 0 on success, nonzero if setup was not created for
+     PFFFT_REAL.
+  */
+  PFFFT_EXPORT int pffftd_zconvolve_zp(const PFFFTD_Setup *setup, const double *dft_x, const double *dft_hzp, double *dft_ab);
+
+  /*
      deprecated synonym for pffftd_zconvolve_scale()
   */
   PFFFT_EXPORT void PFFFT_DEPRECATED pffftd_zconvolve_no_accu(const PFFFTD_Setup *setup, const double *dft_a, const double *dft_b, double *dft_ab, double scaling);

--- a/src/pffastconv.c
+++ b/src/pffastconv.c
@@ -185,7 +185,7 @@ int pffastconv_apply(PFFASTCONV_Setup * s, const float *input_, int cplxInputLen
         pffft_transform(s->st, s->Xt, s->Xf, /* tmp = */ s->Mf, PFFFT_FORWARD);
       }
 
-      pffft_zconvolve_no_accu(s->st, s->Xf, s->Hf, /* tmp = */ s->Mf, s->scale);
+      pffft_zconvolve_scale(s->st, s->Xf, s->Hf, /* tmp = */ s->Mf, s->scale);
 
       if ( flags & PFFASTCONV_DIRECT_OUT )
       {
@@ -235,7 +235,7 @@ int pffastconv_apply(PFFASTCONV_Setup * s, const float *input_, int cplxInputLen
           pffft_transform(s->st, s->Xt, s->Xf, /* tmp = */ s->Mf, PFFFT_FORWARD);
         }
 
-        pffft_zconvolve_no_accu(s->st, s->Xf, s->Hf, /* tmp = */ s->Mf, s->scale);
+        pffft_zconvolve_scale(s->st, s->Xf, s->Hf, /* tmp = */ s->Mf, s->scale);
 
         if ( flags & PFFASTCONV_CPLX_INP_OUT )
         {

--- a/src/pffft.c
+++ b/src/pffft.c
@@ -105,7 +105,7 @@
 #define FUNC_TRANSFORM_ORDERED     pffft_transform_ordered
 #define FUNC_ZREORDER              pffft_zreorder
 #define FUNC_ZCONVOLVE_ACCUMULATE  pffft_zconvolve_accumulate
-#define FUNC_ZCONVOLVE_NO_ACCU     pffft_zconvolve_no_accu
+#define FUNC_ZCONVOLVE_SCALE       pffft_zconvolve_scale
 
 #define FUNC_ALIGNED_MALLOC        pffft_aligned_malloc
 #define FUNC_ALIGNED_FREE          pffft_aligned_free
@@ -132,3 +132,8 @@
 #include "pffft_priv_impl.h"
 
 
+
+/* deprecated synonym for pffft_zconvolve_scale() -- kept for ABI compatibility */
+void pffft_zconvolve_no_accu(const PFFFT_Setup *setup, const float *dft_a, const float *dft_b, float *dft_ab, float scaling) {
+  pffft_zconvolve_scale(setup, dft_a, dft_b, dft_ab, scaling);
+}

--- a/src/pffft.c
+++ b/src/pffft.c
@@ -105,6 +105,7 @@
 #define FUNC_TRANSFORM_ORDERED     pffft_transform_ordered
 #define FUNC_ZREORDER              pffft_zreorder
 #define FUNC_ZCONVOLVE_ACCUMULATE  pffft_zconvolve_accumulate
+#define FUNC_ZCONVOLVE              pffft_zconvolve
 #define FUNC_ZCONVOLVE_SCALE       pffft_zconvolve_scale
 
 #define FUNC_ALIGNED_MALLOC        pffft_aligned_malloc

--- a/src/pffft.c
+++ b/src/pffft.c
@@ -106,6 +106,8 @@
 #define FUNC_ZREORDER              pffft_zreorder
 #define FUNC_ZCONVOLVE_ACCUMULATE  pffft_zconvolve_accumulate
 #define FUNC_ZCONVOLVE              pffft_zconvolve
+#define FUNC_ZCONVERT_ZP            pffft_zconvert_zp
+#define FUNC_ZCONVOLVE_ZP           pffft_zconvolve_zp
 #define FUNC_ZCONVOLVE_SCALE       pffft_zconvolve_scale
 
 #define FUNC_ALIGNED_MALLOC        pffft_aligned_malloc

--- a/src/pffft_double.c
+++ b/src/pffft_double.c
@@ -120,6 +120,7 @@
 #define FUNC_TRANSFORM_ORDERED     pffftd_transform_ordered
 #define FUNC_ZREORDER              pffftd_zreorder
 #define FUNC_ZCONVOLVE_ACCUMULATE  pffftd_zconvolve_accumulate
+#define FUNC_ZCONVOLVE              pffftd_zconvolve
 #define FUNC_ZCONVOLVE_SCALE       pffftd_zconvolve_scale
 
 #define FUNC_ALIGNED_MALLOC        pffftd_aligned_malloc

--- a/src/pffft_double.c
+++ b/src/pffft_double.c
@@ -71,7 +71,9 @@
 #endif
 
 #ifdef COMPILER_MSVC
-#  define _USE_MATH_DEFINES
+#  ifndef _USE_MATH_DEFINES
+#    define _USE_MATH_DEFINES
+#  endif
 #  include <malloc.h>
 #elif defined(__MINGW32__) || defined(__MINGW64__)
 #  include <malloc.h>

--- a/src/pffft_double.c
+++ b/src/pffft_double.c
@@ -121,6 +121,8 @@
 #define FUNC_ZREORDER              pffftd_zreorder
 #define FUNC_ZCONVOLVE_ACCUMULATE  pffftd_zconvolve_accumulate
 #define FUNC_ZCONVOLVE              pffftd_zconvolve
+#define FUNC_ZCONVERT_ZP            pffftd_zconvert_zp
+#define FUNC_ZCONVOLVE_ZP           pffftd_zconvolve_zp
 #define FUNC_ZCONVOLVE_SCALE       pffftd_zconvolve_scale
 
 #define FUNC_ALIGNED_MALLOC        pffftd_aligned_malloc

--- a/src/pffft_double.c
+++ b/src/pffft_double.c
@@ -120,7 +120,7 @@
 #define FUNC_TRANSFORM_ORDERED     pffftd_transform_ordered
 #define FUNC_ZREORDER              pffftd_zreorder
 #define FUNC_ZCONVOLVE_ACCUMULATE  pffftd_zconvolve_accumulate
-#define FUNC_ZCONVOLVE_NO_ACCU     pffftd_zconvolve_no_accu
+#define FUNC_ZCONVOLVE_SCALE       pffftd_zconvolve_scale
 
 #define FUNC_ALIGNED_MALLOC        pffftd_aligned_malloc
 #define FUNC_ALIGNED_FREE          pffftd_aligned_free
@@ -147,3 +147,8 @@
 #include "pffft_priv_impl.h"
 
 
+
+/* deprecated synonym for pffftd_zconvolve_scale() -- kept for ABI compatibility */
+void pffftd_zconvolve_no_accu(const PFFFTD_Setup *setup, const double *dft_a, const double *dft_b, double *dft_ab, double scaling) {
+  pffftd_zconvolve_scale(setup, dft_a, dft_b, dft_ab, scaling);
+}

--- a/src/pffft_priv_impl.h
+++ b/src/pffft_priv_impl.h
@@ -1740,7 +1740,8 @@ int FUNC_ZCONVERT_ZP(const SETUP_STRUCT *s, const float *in, float *out, float s
   /* no RESTRICT: in may alias out by contract */
   const v4sf *vin = (const v4sf*)in;
   v4sf *vout = (v4sf*)out;
-  v4sf vs = LD_PS1(scaling);
+  const float nscaling = scaling / (float)s->N;  /* unit-gain normalization */
+  v4sf vs = LD_PS1(nscaling);
   if (s->transform != PFFFT_REAL) return -1;
   assert(VALIGNED(in) && VALIGNED(out));
   /*
@@ -1750,12 +1751,17 @@ int FUNC_ZCONVERT_ZP(const SETUP_STRUCT *s, const float *in, float *out, float s
     Nyquist coefficient F(N/2) next to F(0) in vector 0 (same packing
     that pffft_zconvolve_accumulate() treats component-wise).
     Zero-phase form: keep/scale the real vectors, zero the imag
-    vectors, keep/scale the Nyquist lane. */
+    vectors, keep/scale the Nyquist lane.
+
+    The conversion applies a 1/N factor (times 'scaling'): with
+    scaling == 1, transform(x, FORWARD) -> zconvolve_zp() ->
+    transform(.., BACKWARD) yields the circular convolution of x
+    with the filter at unit gain. */
   vout[0] = VMUL(vin[0], vs);
   {
     /* latch the scaled Nyquist coefficient before zeroing: with
        in == out the vector store below would destroy vin[1].f[0] */
-    const float nyquist = ((const v4sf_union*)vin)[1].f[0] * scaling;
+    const float nyquist = ((const v4sf_union*)vin)[1].f[0] * nscaling;
     const v4sf vz = VZERO();
     vout[1] = vz;
     ((v4sf_union*)vout)[1].f[0] = nyquist;
@@ -1952,12 +1958,13 @@ void pffft_zconvolve_nosimd(const SETUP_STRUCT *s, const float *a, const float *
 
 #define pffft_zconvert_zp_nosimd FUNC_ZCONVERT_ZP
 int pffft_zconvert_zp_nosimd(const SETUP_STRUCT *s, const float *in, float *out, float scaling) {
-  int k, N2 = s->Ncvec * 2;  /* number of floats: [F0, F1r, F1i .. F(n/2-1)i, F(n/2)] */
+  int k, N2 = s->Ncvec * 2;
+  float nscaling = scaling / (float)s->N;  /* unit-gain normalization */
   if (s->transform != PFFFT_REAL) return -1;
-  out[0] = in[0] * scaling;
-  out[N2-1] = in[N2-1] * scaling;
+  out[0] = in[0] * nscaling;
+  out[N2-1] = in[N2-1] * nscaling;
   for (k = 1; k < N2-1; k += 2) {
-    out[k] = in[k] * scaling;
+    out[k] = in[k] * nscaling;
     out[k+1] = 0.f;
   }
   return 0;

--- a/src/pffft_priv_impl.h
+++ b/src/pffft_priv_impl.h
@@ -1155,7 +1155,7 @@ static void unreversed_copy(int N, const v4sf *in, v4sf *out, int out_stride) {
   UNINTERLEAVE2(h0, g1, out[0], out[1]);
 }
 
-void FUNC_ZREORDER(SETUP_STRUCT *setup, const float *in, float *out, pffft_direction_t direction) {
+void FUNC_ZREORDER(const SETUP_STRUCT *setup, const float *in, float *out, pffft_direction_t direction) {
   int k, N = setup->N, Ncvec = setup->Ncvec;
   const v4sf *vin = (const v4sf*)in;
   v4sf *vout = (v4sf*)out;
@@ -1462,7 +1462,7 @@ static NEVER_INLINE(void) FUNC_REAL_PREPROCESS(int Ncvec, const v4sf *in, v4sf *
 }
 
 
-void FUNC_TRANSFORM_INTERNAL(SETUP_STRUCT *setup, const float *finput, float *foutput, v4sf *scratch,
+void FUNC_TRANSFORM_INTERNAL(const SETUP_STRUCT *setup, const float *finput, float *foutput, v4sf *scratch,
                              pffft_direction_t direction, int ordered) {
   int k, Ncvec   = setup->Ncvec;
   int nf_odd = (setup->ifac[1] & 1);
@@ -1531,7 +1531,7 @@ void FUNC_TRANSFORM_INTERNAL(SETUP_STRUCT *setup, const float *finput, float *fo
   assert(buff[ib] == voutput);
 }
 
-void FUNC_ZCONVOLVE_ACCUMULATE(SETUP_STRUCT *s, const float *a, const float *b, float *ab, float scaling) {
+void FUNC_ZCONVOLVE_ACCUMULATE(const SETUP_STRUCT *s, const float *a, const float *b, float *ab, float scaling) {
   int Ncvec = s->Ncvec;
   const v4sf * RESTRICT va = (const v4sf*)a;
   const v4sf * RESTRICT vb = (const v4sf*)b;
@@ -1629,7 +1629,7 @@ void FUNC_ZCONVOLVE_ACCUMULATE(SETUP_STRUCT *s, const float *a, const float *b, 
   }
 }
 
-void FUNC_ZCONVOLVE_NO_ACCU(SETUP_STRUCT *s, const float *a, const float *b, float *ab, float scaling) {
+void FUNC_ZCONVOLVE_NO_ACCU(const SETUP_STRUCT *s, const float *a, const float *b, float *ab, float scaling) {
   v4sf vscal = LD_PS1(scaling);
   const v4sf * RESTRICT va = (const v4sf*)a;
   const v4sf * RESTRICT vb = (const v4sf*)b;
@@ -1689,7 +1689,7 @@ void FUNC_ZCONVOLVE_NO_ACCU(SETUP_STRUCT *s, const float *a, const float *b, flo
 /* standard routine using scalar floats, without SIMD stuff. */
 
 #define pffft_zreorder_nosimd FUNC_ZREORDER
-void pffft_zreorder_nosimd(SETUP_STRUCT *setup, const float *in, float *out, pffft_direction_t direction) {
+void pffft_zreorder_nosimd(const SETUP_STRUCT *setup, const float *in, float *out, pffft_direction_t direction) {
   int k, N = setup->N;
   if (setup->transform == PFFFT_COMPLEX) {
     for (k=0; k < 2*N; ++k) out[k] = in[k];
@@ -1709,7 +1709,7 @@ void pffft_zreorder_nosimd(SETUP_STRUCT *setup, const float *in, float *out, pff
 }
 
 #define pffft_transform_internal_nosimd FUNC_TRANSFORM_INTERNAL
-void pffft_transform_internal_nosimd(SETUP_STRUCT *setup, const float *input, float *output, float *scratch,
+void pffft_transform_internal_nosimd(const SETUP_STRUCT *setup, const float *input, float *output, float *scratch,
                                     pffft_direction_t direction, int ordered) {
   int Ncvec   = setup->Ncvec;
   int nf_odd = (setup->ifac[1] & 1);
@@ -1766,7 +1766,7 @@ void pffft_transform_internal_nosimd(SETUP_STRUCT *setup, const float *input, fl
 }
 
 #define pffft_zconvolve_accumulate_nosimd FUNC_ZCONVOLVE_ACCUMULATE
-void pffft_zconvolve_accumulate_nosimd(SETUP_STRUCT *s, const float *a, const float *b,
+void pffft_zconvolve_accumulate_nosimd(const SETUP_STRUCT *s, const float *a, const float *b,
                                        float *ab, float scaling) {
   int NcvecMulTwo = 2*s->Ncvec;  /* int Ncvec = s->Ncvec; */
   int k; /* was i -- but always used "2*i" - except at for() */
@@ -1788,7 +1788,7 @@ void pffft_zconvolve_accumulate_nosimd(SETUP_STRUCT *s, const float *a, const fl
 }
 
 #define pffft_zconvolve_no_accu_nosimd FUNC_ZCONVOLVE_NO_ACCU
-void pffft_zconvolve_no_accu_nosimd(SETUP_STRUCT *s, const float *a, const float *b,
+void pffft_zconvolve_no_accu_nosimd(const SETUP_STRUCT *s, const float *a, const float *b,
                                     float *ab, float scaling) {
   int NcvecMulTwo = 2*s->Ncvec;  /* int Ncvec = s->Ncvec; */
   int k; /* was i -- but always used "2*i" - except at for() */
@@ -1813,11 +1813,11 @@ void pffft_zconvolve_no_accu_nosimd(SETUP_STRUCT *s, const float *a, const float
 #endif /* #if ( SIMD_SZ == 4 )    * !defined(PFFFT_SIMD_DISABLE) */
 
 
-void FUNC_TRANSFORM_UNORDRD(SETUP_STRUCT *setup, const float *input, float *output, float *work, pffft_direction_t direction) {
+void FUNC_TRANSFORM_UNORDRD(const SETUP_STRUCT *setup, const float *input, float *output, float *work, pffft_direction_t direction) {
   FUNC_TRANSFORM_INTERNAL(setup, input, output, (v4sf*)work, direction, 0);
 }
 
-void FUNC_TRANSFORM_ORDERED(SETUP_STRUCT *setup, const float *input, float *output, float *work, pffft_direction_t direction) {
+void FUNC_TRANSFORM_ORDERED(const SETUP_STRUCT *setup, const float *input, float *output, float *work, pffft_direction_t direction) {
   FUNC_TRANSFORM_INTERNAL(setup, input, output, (v4sf*)work, direction, 1);
 }
 

--- a/src/pffft_priv_impl.h
+++ b/src/pffft_priv_impl.h
@@ -1734,6 +1734,73 @@ void FUNC_ZCONVOLVE(const SETUP_STRUCT *s, const float *a, const float *b, float
   }
 }
 
+
+int FUNC_ZCONVERT_ZP(const SETUP_STRUCT *s, const float *in, float *out, float scaling) {
+  int j, nv = s->Ncvec * 2;  /* number of simd vectors: alternating real/imag vector pairs */
+  /* no RESTRICT: in may alias out by contract */
+  const v4sf *vin = (const v4sf*)in;
+  v4sf *vout = (v4sf*)out;
+  v4sf vs = LD_PS1(scaling);
+  if (s->transform != PFFFT_REAL) return -1;
+  assert(VALIGNED(in) && VALIGNED(out));
+  /*
+    unordered forward REAL layout: even-indexed vectors hold the real
+    parts of 4 coefficients each, odd-indexed vectors their imaginary
+    parts -- except the very first odd lane, which packs the real
+    Nyquist coefficient F(N/2) next to F(0) in vector 0 (same packing
+    that pffft_zconvolve_accumulate() treats component-wise).
+    Zero-phase form: keep/scale the real vectors, zero the imag
+    vectors, keep/scale the Nyquist lane. */
+  vout[0] = VMUL(vin[0], vs);
+  {
+    /* latch the scaled Nyquist coefficient before zeroing: with
+       in == out the vector store below would destroy vin[1].f[0] */
+    const float nyquist = ((const v4sf_union*)vin)[1].f[0] * scaling;
+    const v4sf vz = VZERO();
+    vout[1] = vz;
+    ((v4sf_union*)vout)[1].f[0] = nyquist;
+    for (j = 2; j < nv; j += 2) {
+      vout[j] = VMUL(vin[j], vs);
+      vout[j+1] = vz;
+    }
+  }
+  return 0;
+}
+
+int FUNC_ZCONVOLVE_ZP(const SETUP_STRUCT *s, const float *x, const float *hzp, float *ab) {
+  int j, np = s->Ncvec;  /* number of real/imag vector pairs */
+  /* no RESTRICT: any pair of pointers may alias by contract */
+  const v4sf *vx = (const v4sf*)x;
+  const v4sf *vh = (const v4sf*)hzp;
+  v4sf *vab = (v4sf*)ab;
+  if (s->transform != PFFFT_REAL) return -1;
+  assert(VALIGNED(x) && VALIGNED(hzp) && VALIGNED(ab));
+  /*
+    with a zero-phase filter (imag vectors all zero):
+    Y_re = X_re * H_re   and   Y_im = X_im * H_re.
+    The first two vectors additionally carry the real DC and Nyquist
+    coefficients in their f[0] lanes (see FUNC_ZCONVERT_ZP), so that
+    pair is finished scalar-wise, component-wise, exactly like
+    FUNC_ZCONVOLVE_ACCUMULATE() does. */
+  {
+    /* note: the Nyquist product reads hv1.f[0], not hv0.f[0] */
+    v4sf_union xv1, hv0, hv1;
+    xv1.v = vx[1];
+    hv0.v = vh[0]; hv1.v = vh[1];
+    vab[0] = VMUL(vx[0], vh[0]);
+    ((v4sf_union*)vab)[1].f[0] = xv1.f[0] * hv1.f[0];
+    ((v4sf_union*)vab)[1].f[1] = xv1.f[1] * hv0.f[1];
+    ((v4sf_union*)vab)[1].f[2] = xv1.f[2] * hv0.f[2];
+    ((v4sf_union*)vab)[1].f[3] = xv1.f[3] * hv0.f[3];
+  }
+  for (j = 1; j < np; ++j) {
+    v4sf hr = vh[2*j];
+    vab[2*j] = VMUL(vx[2*j], hr);
+    vab[2*j+1] = VMUL(vx[2*j+1], hr);
+  }
+  return 0;
+}
+
 #else  /* #if ( SIMD_SZ == 4 )   * !defined(PFFFT_SIMD_DISABLE) */
 
 /* standard routine using scalar floats, without SIMD stuff. */
@@ -1880,6 +1947,34 @@ void pffft_zconvolve_nosimd(const SETUP_STRUCT *s, const float *a, const float *
     ab[k+0] = ar;
     ab[k+1] = ai;
   }
+}
+
+
+#define pffft_zconvert_zp_nosimd FUNC_ZCONVERT_ZP
+int pffft_zconvert_zp_nosimd(const SETUP_STRUCT *s, const float *in, float *out, float scaling) {
+  int k, N2 = s->Ncvec * 2;  /* number of floats: [F0, F1r, F1i .. F(n/2-1)i, F(n/2)] */
+  if (s->transform != PFFFT_REAL) return -1;
+  out[0] = in[0] * scaling;
+  out[N2-1] = in[N2-1] * scaling;
+  for (k = 1; k < N2-1; k += 2) {
+    out[k] = in[k] * scaling;
+    out[k+1] = 0.f;
+  }
+  return 0;
+}
+
+#define pffft_zconvolve_zp_nosimd FUNC_ZCONVOLVE_ZP
+int pffft_zconvolve_zp_nosimd(const SETUP_STRUCT *s, const float *x, const float *hzp, float *ab) {
+  int k, N2 = s->Ncvec * 2;
+  if (s->transform != PFFFT_REAL) return -1;
+  ab[0] = x[0] * hzp[0];
+  ab[N2-1] = x[N2-1] * hzp[N2-1];
+  for (k = 1; k < N2-1; k += 2) {
+    float hr = hzp[k];
+    ab[k] = x[k] * hr;
+    ab[k+1] = x[k+1] * hr;
+  }
+  return 0;
 }
 
 #endif /* #if ( SIMD_SZ == 4 )    * !defined(PFFFT_SIMD_DISABLE) */

--- a/src/pffft_priv_impl.h
+++ b/src/pffft_priv_impl.h
@@ -1629,7 +1629,7 @@ void FUNC_ZCONVOLVE_ACCUMULATE(const SETUP_STRUCT *s, const float *a, const floa
   }
 }
 
-void FUNC_ZCONVOLVE_NO_ACCU(const SETUP_STRUCT *s, const float *a, const float *b, float *ab, float scaling) {
+void FUNC_ZCONVOLVE_SCALE(const SETUP_STRUCT *s, const float *a, const float *b, float *ab, float scaling) {
   v4sf vscal = LD_PS1(scaling);
   const v4sf * RESTRICT va = (const v4sf*)a;
   const v4sf * RESTRICT vb = (const v4sf*)b;
@@ -1787,8 +1787,8 @@ void pffft_zconvolve_accumulate_nosimd(const SETUP_STRUCT *s, const float *a, co
   }
 }
 
-#define pffft_zconvolve_no_accu_nosimd FUNC_ZCONVOLVE_NO_ACCU
-void pffft_zconvolve_no_accu_nosimd(const SETUP_STRUCT *s, const float *a, const float *b,
+#define pffft_zconvolve_scale_nosimd FUNC_ZCONVOLVE_SCALE
+void pffft_zconvolve_scale_nosimd(const SETUP_STRUCT *s, const float *a, const float *b,
                                     float *ab, float scaling) {
   int NcvecMulTwo = 2*s->Ncvec;  /* int Ncvec = s->Ncvec; */
   int k; /* was i -- but always used "2*i" - except at for() */

--- a/src/pffft_priv_impl.h
+++ b/src/pffft_priv_impl.h
@@ -1912,8 +1912,8 @@ void pffft_zconvolve_scale_nosimd(const SETUP_STRUCT *s, const float *a, const f
 
   if (s->transform == PFFFT_REAL) {
     /* take care of the fftpack ordering */
-    ab[0] += a[0]*b[0]*scaling;
-    ab[NcvecMulTwo-1] += a[NcvecMulTwo-1]*b[NcvecMulTwo-1]*scaling;
+    ab[0] = a[0]*b[0]*scaling;
+    ab[NcvecMulTwo-1] = a[NcvecMulTwo-1]*b[NcvecMulTwo-1]*scaling;
     ++ab; ++a; ++b; NcvecMulTwo -= 2;
   }
   for (k=0; k < NcvecMulTwo; k += 2) {

--- a/src/pffft_priv_impl.h
+++ b/src/pffft_priv_impl.h
@@ -1684,6 +1684,56 @@ void FUNC_ZCONVOLVE_SCALE(const SETUP_STRUCT *s, const float *a, const float *b,
 }
 
 
+void FUNC_ZCONVOLVE(const SETUP_STRUCT *s, const float *a, const float *b, float *ab) {
+  const v4sf * RESTRICT va = (const v4sf*)a;
+  const v4sf * RESTRICT vb = (const v4sf*)b;
+  v4sf * RESTRICT vab = (v4sf*)ab;
+  float sar, sai, sbr, sbi;
+  const int NcvecMulTwo = 2*s->Ncvec;  /* int Ncvec = s->Ncvec; */
+  int k; /* was i -- but always used "2*i" - except at for() */
+
+#ifdef __arm__
+  __builtin_prefetch(va);
+  __builtin_prefetch(vb);
+  __builtin_prefetch(vab);
+  __builtin_prefetch(va+2);
+  __builtin_prefetch(vb+2);
+  __builtin_prefetch(vab+2);
+  __builtin_prefetch(va+4);
+  __builtin_prefetch(vb+4);
+  __builtin_prefetch(vab+4);
+  __builtin_prefetch(va+6);
+  __builtin_prefetch(vb+6);
+  __builtin_prefetch(vab+6);
+#endif
+
+  assert(VALIGNED(a) && VALIGNED(b) && VALIGNED(ab));
+  sar = ((v4sf_union*)va)[0].f[0];
+  sai = ((v4sf_union*)va)[1].f[0];
+  sbr = ((v4sf_union*)vb)[0].f[0];
+  sbi = ((v4sf_union*)vb)[1].f[0];
+
+  /* default routine, works fine for non-arm cpus with current compilers */
+  for (k=0; k < NcvecMulTwo; k += 4) {
+    v4sf var, vai, vbr, vbi;
+    var = va[k+0]; vai = va[k+1];
+    vbr = vb[k+0]; vbi = vb[k+1];
+    VCPLXMUL(var, vai, vbr, vbi);
+    vab[k+0] = var;
+    vab[k+1] = vai;
+    var = va[k+2]; vai = va[k+3];
+    vbr = vb[k+2]; vbi = vb[k+3];
+    VCPLXMUL(var, vai, vbr, vbi);
+    vab[k+2] = var;
+    vab[k+3] = vai;
+  }
+
+  if (s->transform == PFFFT_REAL) {
+    ((v4sf_union*)vab)[0].f[0] = sar*sbr;
+    ((v4sf_union*)vab)[1].f[0] = sai*sbi;
+  }
+}
+
 #else  /* #if ( SIMD_SZ == 4 )   * !defined(PFFFT_SIMD_DISABLE) */
 
 /* standard routine using scalar floats, without SIMD stuff. */
@@ -1809,6 +1859,28 @@ void pffft_zconvolve_scale_nosimd(const SETUP_STRUCT *s, const float *a, const f
   }
 }
 
+
+#define pffft_zconvolve_nosimd FUNC_ZCONVOLVE
+void pffft_zconvolve_nosimd(const SETUP_STRUCT *s, const float *a, const float *b,
+                            float *ab) {
+  int NcvecMulTwo = 2*s->Ncvec;  /* int Ncvec = s->Ncvec; */
+  int k; /* was i -- but always used "2*i" - except at for() */
+
+  if (s->transform == PFFFT_REAL) {
+    /* take care of the fftpack ordering */
+    ab[0] = a[0]*b[0];
+    ab[NcvecMulTwo-1] = a[NcvecMulTwo-1]*b[NcvecMulTwo-1];
+    ++ab; ++a; ++b; NcvecMulTwo -= 2;
+  }
+  for (k=0; k < NcvecMulTwo; k += 2) {
+    float ar, ai, br, bi;
+    ar = a[k+0]; ai = a[k+1];
+    br = b[k+0]; bi = b[k+1];
+    VCPLXMUL(ar, ai, br, bi);
+    ab[k+0] = ar;
+    ab[k+1] = ai;
+  }
+}
 
 #endif /* #if ( SIMD_SZ == 4 )    * !defined(PFFFT_SIMD_DISABLE) */
 

--- a/tests/test_fft_factors.c
+++ b/tests/test_fft_factors.c
@@ -33,7 +33,9 @@ int test_float(int TL)
       fprintf(stderr, "testing float, %s, %s ..\tminimum transform %d; nearest transform for %d is %d (%.2f%% off)\n",
           (!dir_i) ? "FORWARD" : "BACKWARD", (!cplx_i) ? "REAL" : "COMPLEX", N_min, TL, NTL, near_off );
 
-      for (int N = (N_min/2); N <= N_max; N += (N_min/2))
+      /* step 0 when N_min == 1 (complex, SIMD_SZ==1): infinite loop */
+      const int N_step = (N_min/2) ? (N_min/2) : 1;
+      for (int N = (N_min/2); N <= N_max; N += N_step)
       {
         int R = N, f2 = 0, f3 = 0, f5 = 0, tmp_f;
         const int factorizable = pffft_is_valid_size(N, cplx);
@@ -86,7 +88,9 @@ int test_double(int TL)
       fprintf(stderr, "testing double, %s, %s ..\tminimum transform %d; nearest transform for %d is %d (%.2f%% off)\n",
           (!dir_i) ? "FORWARD" : "BACKWARD", (!cplx_i) ? "REAL" : "COMPLEX", N_min, TL, NTL, near_off );
 
-      for (int N = (N_min/2); N <= N_max; N += (N_min/2))
+      /* step 0 when N_min == 1 (complex, SIMD_SZ==1): infinite loop */
+      const int N_step = (N_min/2) ? (N_min/2) : 1;
+      for (int N = (N_min/2); N <= N_max; N += N_step)
       {
         int R = N, f2 = 0, f3 = 0, f5 = 0, tmp_f;
         const int factorizable = pffftd_is_valid_size(N, cplx);

--- a/tests/test_pffastconv.c
+++ b/tests/test_pffastconv.c
@@ -514,7 +514,7 @@ int test(int FILTERLEN, int convFlags, const int testOutLen, int printDbg, int p
     else
       Y[i] = Y[1];
 
-    Y[i][0] = 123.F;  /* test for pffft_zconvolve_no_accu() */
+    Y[i][0] = 123.F;  /* test for pffft_zconvolve_scale() */
     aSpeedFactor[i] = -1.0;
     aDuration[i] = -1.0;
     procSmpPerSec[i] = -1.0;

--- a/tests/test_pffft.c
+++ b/tests/test_pffft.c
@@ -265,6 +265,79 @@ int test(int N, int cplx, int useOrdered) {
   return retError;
 }
 
+/* check that pffft_zconvolve() matches pffft_zconvolve_scale(.., 1.0)
+   bit-exactly, and that circular convolution with a delayed impulse
+   delays the signal (the backward transform carries the usual factor N) */
+static int test_zconvolve_unscaled(int N)
+{
+  int j, retError = 0;
+#ifdef PFFFT_ENABLE_FLOAT
+  typedef PFFFT_Setup setup_t;
+#define ZT_NEW_SETUP     pffft_new_setup
+#define ZT_DESTROY_SETUP pffft_destroy_setup
+#define ZT_TRANSFORM     pffft_transform
+#define ZT_ZCONVOLVE     pffft_zconvolve
+#define ZT_ZCONV_SCALE   pffft_zconvolve_scale
+#define ZT_MALLOC        pffft_aligned_malloc
+#define ZT_FREE          pffft_aligned_free
+#else
+  typedef PFFFTD_Setup setup_t;
+#define ZT_NEW_SETUP     pffftd_new_setup
+#define ZT_DESTROY_SETUP pffftd_destroy_setup
+#define ZT_TRANSFORM     pffftd_transform
+#define ZT_ZCONVOLVE     pffftd_zconvolve
+#define ZT_ZCONV_SCALE   pffftd_zconvolve_scale
+#define ZT_MALLOC        pffftd_aligned_malloc
+#define ZT_FREE          pffftd_aligned_free
+#endif
+  setup_t *s;
+  pffft_scalar *X, *H, *SX, *SH, *CNew, *CRef, *Y, *W;
+
+  s = ZT_NEW_SETUP(N, PFFFT_REAL);
+  assert(s);
+  X    = (pffft_scalar*)ZT_MALLOC(N * sizeof(pffft_scalar));
+  H    = (pffft_scalar*)ZT_MALLOC(N * sizeof(pffft_scalar));
+  SX   = (pffft_scalar*)ZT_MALLOC(N * sizeof(pffft_scalar));
+  SH   = (pffft_scalar*)ZT_MALLOC(N * sizeof(pffft_scalar));
+  CNew = (pffft_scalar*)ZT_MALLOC(N * sizeof(pffft_scalar));
+  CRef = (pffft_scalar*)ZT_MALLOC(N * sizeof(pffft_scalar));
+  Y    = (pffft_scalar*)ZT_MALLOC(N * sizeof(pffft_scalar));
+  W    = (pffft_scalar*)ZT_MALLOC(N * sizeof(pffft_scalar));
+
+  for ( j = 0; j < N; ++j ) {
+    X[j] = (pffft_scalar)(sin(0.1*j) + 0.3*cos(0.9*j));
+    H[j] = (j == 4 ? (pffft_scalar)1.0 : (pffft_scalar)0.0); /* impulse delayed by 4 samples */
+  }
+
+  ZT_TRANSFORM(s, X, SX, W, PFFFT_FORWARD);
+  ZT_TRANSFORM(s, H, SH, W, PFFFT_FORWARD);
+
+  ZT_ZCONVOLVE(s, SX, SH, CNew);
+  ZT_ZCONV_SCALE(s, SX, SH, CRef, 1.0);
+
+  if ( memcmp(CNew, CRef, N * sizeof(pffft_scalar)) != 0 ) {
+    printf("real fft %d: zconvolve() differs from zconvolve_scale(.., 1.0)\n", N);
+    retError = 1;
+  }
+
+  ZT_TRANSFORM(s, CNew, Y, W, PFFFT_BACKWARD);
+  for ( j = 0; j < N-4; ++j ) {
+    pffft_scalar expected = (pffft_scalar)(X[j]);
+    pffft_scalar got      = (pffft_scalar)(Y[j+4] / N);
+    if ( fabs(got - expected) > 1e-4 ) {
+      printf("real fft %d: delayed convolution mismatch at j = %d : got %g, expected %g\n",
+             N, j, (double)got, (double)expected);
+      retError = 1;
+      break;
+    }
+  }
+
+  ZT_FREE(X); ZT_FREE(H); ZT_FREE(SX); ZT_FREE(SH);
+  ZT_FREE(CNew); ZT_FREE(CRef); ZT_FREE(Y); ZT_FREE(W);
+  ZT_DESTROY_SETUP(s);
+  return retError;
+}
+
 /* small functions inside pffft.c that will detect (compiler) bugs with respect to simd instructions */
 void validate_pffft_simd();
 int  validate_pffft_simd_ex(FILE * DbgOut);
@@ -276,6 +349,7 @@ int  validate_pffftd_simd_ex(FILE * DbgOut);
 int main(int argc, char **argv)
 {
   int N, result, resN, resAll, i, k, resNextPw2, resIsPw2, resFFT;
+  int resZconv;
 
   int inp_power_of_two[] = { 1, 2, 3, 4, 5, 6, 7, 8,  9, 511, 512,  513 };
   int ref_power_of_two[] = { 1, 2, 4, 4, 8, 8, 8, 8, 16, 512, 512, 1024 };
@@ -360,7 +434,11 @@ int main(int argc, char **argv)
 #endif
   }
 
-  resAll = resNextPw2 | resIsPw2 | resFFT;
+  resZconv = test_zconvolve_unscaled(64);
+  if (!resZconv)
+    printf("zconvolve unscaled tests succeeded successfully.\n");
+
+  resAll = resNextPw2 | resIsPw2 | resFFT | resZconv;
   if (!resAll)
     printf("all tests succeeded successfully.\n");
   else

--- a/tests/test_pffft.c
+++ b/tests/test_pffft.c
@@ -372,7 +372,7 @@ static int test_zerophase(int N)
   setup_t *scplx;
   /* symmetric FIR, centered at t = 0 : taps h[-4 .. 4] */
   pffft_scalar ht[9] = { 0.03, -0.10, 0.25, 0.75, 1.0, 0.75, 0.25, -0.10, 0.03 };
-  pffft_scalar *X, *W, *H, *HZP, *C, *CRef, *Y;
+  pffft_scalar *X, *W, *H, *HZP, *HZPN, *C, *CRef, *Y;
   s = ZT_NEW_SETUP(N, PFFFT_REAL);
   scplx = ZT_NEW_SETUP(N, PFFFT_COMPLEX);
   assert(s && scplx);
@@ -380,6 +380,7 @@ static int test_zerophase(int N)
   W    = (pffft_scalar*)ZT_MALLOC(N * sizeof(pffft_scalar));
   H    = (pffft_scalar*)ZT_MALLOC(N * sizeof(pffft_scalar));
   HZP  = (pffft_scalar*)ZT_MALLOC(N * sizeof(pffft_scalar));
+  HZPN = (pffft_scalar*)ZT_MALLOC(N * sizeof(pffft_scalar));
   C    = (pffft_scalar*)ZT_MALLOC(2 * N * sizeof(pffft_scalar));
   CRef = (pffft_scalar*)ZT_MALLOC(2 * N * sizeof(pffft_scalar));
   Y    = (pffft_scalar*)ZT_MALLOC(2 * N * sizeof(pffft_scalar));
@@ -466,9 +467,36 @@ static int test_zerophase(int N)
       }
     }
   }
+  /* unit-gain round trip: with scaling == 1, the 1/N applied by
+     zconvert_zp() completes the backward transform's factor N, so Y
+     must match the direct time-domain circular convolution without
+     any rescaling */
+  {
+    for ( j = 0; j < N; ++j )
+      CRef[j] = C[j];
+    ZT_ZCONVOLVE_ZP(s, CRef, HZP, CRef);        /* in-place is documented legal */
+    ZT_TRANSFORM(s, CRef, Y, NULL, PFFFT_BACKWARD);
+    for ( j = 0; j < N; ++j ) {
+      pffft_scalar ref = 0;
+      for ( k = -4; k <= 4; ++k )
+        ref += (pffft_scalar)(ht[4+k] * X[(j-k+N) % N]);
+      if ( fabs((double)(Y[j]) - (double)(ref)) > 1e-4 * (fabs((double)ref) + 1.0) ) {
+        printf("zero-phase fft %d: sample %d : got %g expected %g\n", N, j, (double)(Y[j]), (double)ref);
+        retError = 1;
+        break;
+      }
+    }
+  }
 
-  ZT_ZCONV_SCALE(s, C, HZP, CRef, 1.0);       /* reference from pristine C */
-  ZT_ZCONVOLVE_ZP(s, C, HZP, C);              /* in-place is documented legal */
+  /* bit-exact cross-check against the plain complex multiply:
+     converting with scaling == N cancels the internal 1/N, restoring
+     the raw zero-phase spectrum */
+  if ( ZT_ZCONVERT_ZP(s, H, HZPN, (pffft_scalar)N) != 0 ) {
+    printf("zero-phase fft %d: zconvert_zp(scaling=N) failed!\n", N);
+    retError = 1;
+  }
+  ZT_ZCONV_SCALE(s, C, HZPN, CRef, 1.0);      /* reference from pristine C */
+  ZT_ZCONVOLVE_ZP(s, C, HZPN, C);             /* in-place is documented legal */
   /* unordered layout is not interleaved re/im pairs: compare flat.
      with a correctly converted zero-phase filter (H_im == 0) the plain
      complex multiply collapses to exactly what the zp path computes, and
@@ -482,22 +510,7 @@ static int test_zerophase(int N)
     }
   }
 
-  ZT_TRANSFORM(s, C, Y, NULL, PFFFT_BACKWARD);
-  /* compare with direct time-domain circular convolution */
-  for ( j = 0; j < N; ++j ) {
-    pffft_scalar ref = 0;
-    for ( k = -4; k <= 4; ++k )
-      ref += (pffft_scalar)(ht[4+k] * X[(j-k+N) % N]);
-    /* no division: the backward transform's factor N completes the
-       unnormalized forward DFT's convention */
-    if ( fabs((double)(Y[j]/N) - (double)(ref)) > 1e-4 * (fabs((double)ref) + 1.0) ) {
-      printf("zero-phase fft %d: sample %d : got %g expected %g\n", N, j, (double)(Y[j]/N), (double)ref);
-      retError = 1;
-      break;
-    }
-  }
-
-  ZT_FREE(X); ZT_FREE(W); ZT_FREE(H); ZT_FREE(HZP); ZT_FREE(C); ZT_FREE(CRef); ZT_FREE(Y);
+  ZT_FREE(X); ZT_FREE(W); ZT_FREE(H); ZT_FREE(HZP); ZT_FREE(HZPN); ZT_FREE(C); ZT_FREE(CRef); ZT_FREE(Y);
   ZT_DESTROY_SETUP(s);
   ZT_DESTROY_SETUP(scplx);
   return retError;

--- a/tests/test_pffft.c
+++ b/tests/test_pffft.c
@@ -276,8 +276,8 @@ static int test_zconvolve_unscaled(int N)
 #define ZT_NEW_SETUP     pffft_new_setup
 #define ZT_DESTROY_SETUP pffft_destroy_setup
 #define ZT_TRANSFORM     pffft_transform
-#define ZT_ZCONVOLVE     pffft_zconvolve
 #define ZT_ZCONV_SCALE   pffft_zconvolve_scale
+#define ZT_ZCONVOLVE     pffft_zconvolve
 #define ZT_MALLOC        pffft_aligned_malloc
 #define ZT_FREE          pffft_aligned_free
 #else
@@ -285,8 +285,8 @@ static int test_zconvolve_unscaled(int N)
 #define ZT_NEW_SETUP     pffftd_new_setup
 #define ZT_DESTROY_SETUP pffftd_destroy_setup
 #define ZT_TRANSFORM     pffftd_transform
-#define ZT_ZCONVOLVE     pffftd_zconvolve
 #define ZT_ZCONV_SCALE   pffftd_zconvolve_scale
+#define ZT_ZCONVOLVE     pffftd_zconvolve
 #define ZT_MALLOC        pffftd_aligned_malloc
 #define ZT_FREE          pffftd_aligned_free
 #endif
@@ -338,6 +338,172 @@ static int test_zconvolve_unscaled(int N)
   return retError;
 }
 
+/* zero-phase filtering check: a linear-phase FIR centered at t = 0
+   with left-hand taps wrapped around the block must produce exactly the
+   circular convolution of the wrapped filter with the signal when its
+   unordered spectrum is converted via pffft_zconvert_zp() and applied
+   with pffft_zconvolve_zp(). Also cross-checks against the plain
+   complex multiply and verifies the REAL-only guard. */
+static int test_zerophase(int N)
+{
+  int j, k, retError = 0;
+#ifdef PFFFT_ENABLE_FLOAT
+  typedef PFFFT_Setup setup_t;
+#define ZT_NEW_SETUP     pffft_new_setup
+#define ZT_DESTROY_SETUP pffft_destroy_setup
+#define ZT_TRANSFORM     pffft_transform
+#define ZT_ZCONVERT_ZP   pffft_zconvert_zp
+#define ZT_ZCONV_SCALE   pffft_zconvolve_scale
+#define ZT_ZCONVOLVE_ZP  pffft_zconvolve_zp
+#define ZT_MALLOC        pffft_aligned_malloc
+#define ZT_FREE          pffft_aligned_free
+#else
+  typedef PFFFTD_Setup setup_t;
+#define ZT_NEW_SETUP     pffftd_new_setup
+#define ZT_DESTROY_SETUP pffftd_destroy_setup
+#define ZT_TRANSFORM     pffftd_transform
+#define ZT_ZCONVERT_ZP   pffftd_zconvert_zp
+#define ZT_ZCONV_SCALE   pffftd_zconvolve_scale
+#define ZT_ZCONVOLVE_ZP  pffftd_zconvolve_zp
+#define ZT_MALLOC        pffftd_aligned_malloc
+#define ZT_FREE          pffftd_aligned_free
+#endif
+  setup_t *s;
+  setup_t *scplx;
+  /* symmetric FIR, centered at t = 0 : taps h[-4 .. 4] */
+  pffft_scalar ht[9] = { 0.03, -0.10, 0.25, 0.75, 1.0, 0.75, 0.25, -0.10, 0.03 };
+  pffft_scalar *X, *W, *H, *HZP, *C, *CRef, *Y;
+  s = ZT_NEW_SETUP(N, PFFFT_REAL);
+  scplx = ZT_NEW_SETUP(N, PFFFT_COMPLEX);
+  assert(s && scplx);
+  X    = (pffft_scalar*)ZT_MALLOC(N * sizeof(pffft_scalar));
+  W    = (pffft_scalar*)ZT_MALLOC(N * sizeof(pffft_scalar));
+  H    = (pffft_scalar*)ZT_MALLOC(N * sizeof(pffft_scalar));
+  HZP  = (pffft_scalar*)ZT_MALLOC(N * sizeof(pffft_scalar));
+  C    = (pffft_scalar*)ZT_MALLOC(2 * N * sizeof(pffft_scalar));
+  CRef = (pffft_scalar*)ZT_MALLOC(2 * N * sizeof(pffft_scalar));
+  Y    = (pffft_scalar*)ZT_MALLOC(2 * N * sizeof(pffft_scalar));
+
+  if ( ZT_ZCONVERT_ZP(scplx, W, HZP, 1.0) == 0 ) {
+    printf("zero-phase fft %d: zconvert_zp accepted a PFFFT_COMPLEX setup!\n", N);
+    retError = 1;
+  }
+  if ( ZT_ZCONVOLVE_ZP(scplx, C, HZP, CRef) == 0 ) {
+    printf("zero-phase fft %d: zconvolve_zp accepted a PFFFT_COMPLEX setup!\n", N);
+    retError = 1;
+  }
+
+  for ( j = 0; j < N; ++j ) {
+    X[j] = (pffft_scalar)(sin(0.37*j) + 0.5*cos(1.71*j + 0.3));
+    W[j] = (pffft_scalar)0.0;
+  }
+  for ( j = 0; j <= 4; ++j )      W[j] = (pffft_scalar)ht[4+j];   /* h[0..4] */
+  for ( j = 1; j <= 4; ++j )      W[N-j] = (pffft_scalar)ht[4-j]; /* h[-4..-1] wrapped */
+
+  ZT_TRANSFORM(s, X, C, NULL, PFFFT_FORWARD);
+  ZT_TRANSFORM(s, W, H, NULL, PFFFT_FORWARD);
+
+  if ( ZT_ZCONVERT_ZP(s, H, HZP, 1.0) != 0 ) {
+    printf("zero-phase fft %d: zconvert_zp failed on a PFFFT_REAL setup!\n", N);
+    retError = 1;
+  }
+
+  /* zero-phase invariants, layout-independent by construction:
+     1) conversion writes EVERY lane of its destination -- sentinel-fill
+        first so unwritten lanes cannot hide (this is exactly what the
+        vector-1 defect violated); no lane-value assumptions needed.
+     2) conversion is linear in scaling.
+     Lane-level value correctness is covered by the cross-check and the
+     time-domain round-trip below, which compare whole buffers without
+     lane-position assumptions. */
+  for ( j = 0; j < N; ++j )
+    CRef[j] = (pffft_scalar)123456789.0;
+  if ( ZT_ZCONVERT_ZP(s, H, CRef, 2.0) != 0 ) {
+    printf("zero-phase fft %d: zconvert_zp(scaling=2) failed!\n", N);
+    retError = 1;
+  }
+  for ( j = 0; j < N; ++j ) {
+    if ( CRef[j] == (pffft_scalar)123456789.0 ) {
+      printf("zero-phase fft %d: zconvert_zp left float %d unwritten\n", N, j);
+      retError = 1;
+      break;
+    }
+  }
+  /* linearity: convert(scaling=1) then double must equal convert(2.0) */
+  {
+    int lin_bad = -1;
+    for ( j = 0; j < N; ++j ) {
+      if ( fabs((double)(HZP[j]*2 - CRef[j])) > 1e-3 * (fabs((double)HZP[j]) + 1.0) ) {
+        lin_bad = j;
+        break;
+      }
+    }
+    if ( lin_bad >= 0 ) {
+      printf("zero-phase fft %d: zconvert_zp not linear in scaling at float %d : 2*%g != %g\n",
+             N, lin_bad, (double)HZP[lin_bad], (double)CRef[lin_bad]);
+      retError = 1;
+    }
+  }
+
+  /* documented aliasing: in == out must work (this was the crux of the
+     vector-1 defect: a naive zero-then-restore order destroys the
+     Nyquist lane before it is read) */
+  {
+    for ( j = 0; j < N; ++j )
+      CRef[j] = H[j];
+    if ( ZT_ZCONVERT_ZP(s, CRef, CRef, 1.0) != 0 ) {
+      printf("zero-phase fft %d: in-place zconvert_zp failed\n", N);
+      retError = 1;
+    }
+    for ( j = 0; j < N; ++j ) {
+      /* identical operations in identical order: any difference is a
+         real defect, so exact comparison */
+      if ( CRef[j] != HZP[j] ) {
+        printf("zero-phase fft %d: in-place zconvert_zp differs from out-of-place at float %d : %g vs %g\n",
+               N, j, (double)CRef[j], (double)HZP[j]);
+        retError = 1;
+        break;
+      }
+    }
+  }
+
+  ZT_ZCONV_SCALE(s, C, HZP, CRef, 1.0);       /* reference from pristine C */
+  ZT_ZCONVOLVE_ZP(s, C, HZP, C);              /* in-place is documented legal */
+  /* unordered layout is not interleaved re/im pairs: compare flat.
+     with a correctly converted zero-phase filter (H_im == 0) the plain
+     complex multiply collapses to exactly what the zp path computes, and
+     zconvolve_scale's REAL epilogue writes the DC and Nyquist lanes with
+     the same component-wise products -- so every float must match. */
+  for ( j = 0; j < N; ++j ) {
+    if ( fabs((double)(C[j] - CRef[j])) > 1e-3 ) {
+      printf("zero-phase fft %d: zp convolve differs from plain convolve at float %d\n", N, j);
+      retError = 1;
+      break;
+    }
+  }
+
+  ZT_TRANSFORM(s, C, Y, NULL, PFFFT_BACKWARD);
+  /* compare with direct time-domain circular convolution */
+  for ( j = 0; j < N; ++j ) {
+    pffft_scalar ref = 0;
+    for ( k = -4; k <= 4; ++k )
+      ref += (pffft_scalar)(ht[4+k] * X[(j-k+N) % N]);
+    /* no division: the backward transform's factor N completes the
+       unnormalized forward DFT's convention */
+    if ( fabs((double)(Y[j]/N) - (double)(ref)) > 1e-4 * (fabs((double)ref) + 1.0) ) {
+      printf("zero-phase fft %d: sample %d : got %g expected %g\n", N, j, (double)(Y[j]/N), (double)ref);
+      retError = 1;
+      break;
+    }
+  }
+
+  ZT_FREE(X); ZT_FREE(W); ZT_FREE(H); ZT_FREE(HZP); ZT_FREE(C); ZT_FREE(CRef); ZT_FREE(Y);
+  ZT_DESTROY_SETUP(s);
+  ZT_DESTROY_SETUP(scplx);
+  return retError;
+}
+
+
 /* small functions inside pffft.c that will detect (compiler) bugs with respect to simd instructions */
 void validate_pffft_simd();
 int  validate_pffft_simd_ex(FILE * DbgOut);
@@ -350,6 +516,7 @@ int main(int argc, char **argv)
 {
   int N, result, resN, resAll, i, k, resNextPw2, resIsPw2, resFFT;
   int resZconv;
+  int resZP;
 
   int inp_power_of_two[] = { 1, 2, 3, 4, 5, 6, 7, 8,  9, 511, 512,  513 };
   int ref_power_of_two[] = { 1, 2, 4, 4, 8, 8, 8, 8, 16, 512, 512, 1024 };
@@ -438,7 +605,11 @@ int main(int argc, char **argv)
   if (!resZconv)
     printf("zconvolve unscaled tests succeeded successfully.\n");
 
-  resAll = resNextPw2 | resIsPw2 | resFFT | resZconv;
+  resZP = test_zerophase(64);
+  if (!resZP)
+    printf("zero-phase convolution tests succeeded successfully.\n");
+
+  resAll = resNextPw2 | resIsPw2 | resFFT | resZconv | resZP;
   if (!resAll)
     printf("all tests succeeded successfully.\n");
   else

--- a/tests/test_pffft.cpp
+++ b/tests/test_pffft.cpp
@@ -352,9 +352,9 @@ ZPtest(int N)
     double ref = 0;
     for (k = -4; k <= 4; ++k)
       ref += double(ht[4 + k]) * double(X[(j - k + N) % N]);
-    if (std::abs(double(Y[j]) / N - ref) > 1e-3) {
+    if (std::abs(double(Y[j]) - ref) > 1e-3) {
       printf("zp wrapper: circular convolution mismatch at %d : %g vs %g\n",
-             j, double(Y[j]) / N, ref);
+             j, double(Y[j]), ref);
       retError = true;
       break;
     }

--- a/tests/test_pffft.cpp
+++ b/tests/test_pffft.cpp
@@ -34,7 +34,9 @@
 
 #include "pffft/pffft.hpp"
 
+#include <algorithm>
 #include <assert.h>
+#include <cmath>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -252,6 +254,114 @@ Ttest(int N, bool useOrdered)
   return retError;
 }
 
+// COMPLEX setups must reject the zero-phase operations. Kept in its own
+// helper so the body is fully instantiable for complex value types too --
+// a combined test function's real-only tail would fail to type-check and
+// make the whole instantiation (and with it this coverage) impossible.
+template<typename T>
+bool
+ZPRejectTest(int N)
+{
+  typedef pffft::Fft<T> Fft;
+  typedef typename Fft::Scalar FftScalar;
+
+  Fft fft(N);
+  pffft::AlignedVector<FftScalar> A = fft.internalLayoutVector();
+  pffft::AlignedVector<FftScalar> B = fft.internalLayoutVector();
+
+  // REAL setups must accept (return 0), COMPLEX setups must reject
+  // (nonzero): the functions are documented REAL-only.
+  const bool expectReject = Fft::isComplexTransform();
+  const int rc1 = fft.zconvertZP(A, B, FftScalar(1));
+  if ((rc1 == 0) == expectReject) {
+    printf("zp wrapper: zconvertZP %s a %s setup\n",
+           (rc1 == 0 ? "accepted" : "rejected"),
+           (expectReject ? "COMPLEX" : "REAL"));
+    return true;
+  }
+  const int rc2 = fft.convolveZP(A, A, B);
+  if ((rc2 == 0) == expectReject) {
+    printf("zp wrapper: convolveZP %s a %s setup\n",
+           (rc2 == 0 ? "accepted" : "rejected"),
+           (expectReject ? "COMPLEX" : "REAL"));
+    return true;
+  }
+  return false;
+}
+
+// exercise the public wrapper surface for the unscaled and zero-phase
+// convolutions added to Fft<T>: unscaled convolve must match
+// convolve(.., 1.0), the zero-phase path must reproduce a time-domain
+// circular convolution, and COMPLEX setups must reject zp conversion.
+template<typename T>
+bool
+ZPtest(int N)
+{
+  typedef pffft::Fft<T> Fft;
+  typedef typename Fft::Scalar FftScalar;
+
+  Fft fft(N);
+
+  pffft::AlignedVector<T> X = fft.valueVector();
+  pffft::AlignedVector<FftScalar> SX = fft.internalLayoutVector();
+  pffft::AlignedVector<FftScalar> W = fft.internalLayoutVector();
+  pffft::AlignedVector<FftScalar> HZP = fft.internalLayoutVector();
+  pffft::AlignedVector<FftScalar> C1 = fft.internalLayoutVector();
+  pffft::AlignedVector<FftScalar> C2 = fft.internalLayoutVector();
+  pffft::AlignedVector<T> Y = fft.valueVector();
+
+  int j, k;
+  bool retError = false;
+
+  for (j = 0; j < N; ++j) {
+    X[j] = T(0.5 * sin(0.37 * j) + 0.25 * cos(1.71 * j + 0.3));
+    W[j] = FftScalar(0);
+  }
+  const FftScalar ht[9] = { FftScalar(0.03), FftScalar(-0.10), FftScalar(0.25),
+                            FftScalar(0.75), FftScalar(1.0),  FftScalar(0.75),
+                            FftScalar(0.25), FftScalar(-0.10), FftScalar(0.03) };
+  for (j = 0; j <= 4; ++j) W[j] = ht[4 + j];
+  for (j = 1; j <= 4; ++j) W[N - j] = ht[4 - j];
+
+  fft.forwardToInternalLayout(X.data(), SX.data());
+  fft.forwardToInternalLayout(reinterpret_cast<const T*>(W.data()), W.data());
+
+  if (fft.zconvertZP(W, HZP, FftScalar(1)) != 0) {
+    printf("zp wrapper: zconvertZP failed on a REAL setup\n");
+    return true;
+  }
+
+  // unscaled public convolve must equal scaled-by-1
+  fft.convolve(SX.data(), HZP.data(), C1.data(), FftScalar(1));
+  fft.convolve(SX.data(), HZP.data(), C2.data());
+  const int layoutSize = fft.getInternalLayoutSize();
+  for (j = 0; j < layoutSize; ++j)
+    if (C1[j] != C2[j]) {
+      printf("zp wrapper: unscaled convolve differs from scaling=1 at %d\n", j);
+      retError = true;
+      break;
+    }
+
+  if (fft.convolveZP(SX, HZP, C1)) {
+    printf("zp wrapper: convolveZP failed on a REAL setup\n");
+    return true;
+  }
+  fft.inverseFromInternalLayout(C1.data(), Y.data());
+
+  for (j = 0; j < N; ++j) {
+    double ref = 0;
+    for (k = -4; k <= 4; ++k)
+      ref += double(ht[4 + k]) * double(X[(j - k + N) % N]);
+    if (std::abs(double(Y[j]) / N - ref) > 1e-3) {
+      printf("zp wrapper: circular convolution mismatch at %d : %g vs %g\n",
+             j, double(Y[j]) / N, ref);
+      retError = true;
+      break;
+    }
+  }
+  return retError;
+}
+
 bool
 test(int N, bool useComplex, bool useOrdered)
 {
@@ -286,6 +396,7 @@ int
 main(int argc, char** argv)
 {
   int N, result, resN, resAll, k, resNextPw2, resIsPw2, resFFT;
+  int resZP = 0;
 
   int inp_power_of_two[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 511, 512, 513 };
   int ref_power_of_two[] = { 1, 2, 4, 4, 8, 8, 8, 8, 16, 512, 512, 1024 };
@@ -367,7 +478,20 @@ main(int argc, char** argv)
 #endif
            ") succeeded successfully.\n");
 
-  resAll = resNextPw2 | resIsPw2 | resFFT;
+#ifdef PFFFT_ENABLE_FLOAT
+  resZP |= ZPRejectTest<float>(64);
+  resZP |= ZPRejectTest< ::std::complex<float> >(64);
+  resZP |= ZPtest<float>(64);
+#endif
+#ifdef PFFFT_ENABLE_DOUBLE
+  resZP |= ZPRejectTest<double>(64);
+  resZP |= ZPRejectTest< ::std::complex<double> >(64);
+  resZP |= ZPtest<double>(64);
+#endif
+  if (!resZP)
+    printf("zero-phase and unscaled convolve wrapper tests succeeded successfully.\n");
+
+  resAll = resNextPw2 | resIsPw2 | resFFT | resZP;
   if (!resAll)
     printf("all tests succeeded successfully.\n");
   else


### PR DESCRIPTION
## Convolution improvements — const setup, unscaled zconvolve, zero-phase convolution, `_USE_MATH_DEFINES` guard

Implements all four suggestions from #101 for **both** the float and double variants (which share one implementation header, so every change lands in both automatically). One suggestion is implemented with a design refinement specific to PFFFT's memory layout — see *Zero-phase convolution* below.

### 1. `const` setup pointers

All functions that only consume the setup (`pffft_transform`, `pffft_transform_ordered`, `pffft_zreorder`, `pffft_zconvolve_*`) now take `const PFFFT_Setup *` / `const PFFFTD_Setup *`. Verified read-only: the twiddle/ifac tables are written exclusively by the `*_ti1_ps()` init functions at setup creation; `rfftf1_ps`/`cfftf1_ps` already took `(const float *wa, const int *ifac)`. Source-compatible with every existing caller; makes sharing one setup across threads formally correct.

### 2. Unscaled `pffft_zconvolve()`

New entry point computing `dft_ab = dft_a * dft_b` with no accumulation and no scaling argument. The scaling factor was a runtime value in the previous kernels, so the compiler could not fold away the dead multiply; removing it saves one vector multiply per SIMD group. As suggested in the issue, rescaling belongs on the static filter side.

Naming: the fork-specific `pffft_zconvolve_no_accu()` (which upstream never had) is renamed to **`pffft_zconvolve_scale()`** so the family reads by what each function *does*:

```c
pffft_zconvolve_accumulate(setup, a, b, ab, scaling); /* ab += a*b*scaling */
pffft_zconvolve_scale     (setup, a, b, ab, scaling); /* ab  = a*b*scaling */
pffft_zconvolve           (setup, a, b, ab);          /* ab  = a*b         */
```

The old name remains as an exported deprecated synonym forwarding to the new symbol — existing binaries keep linking.

### 3. Zero-phase convolution — `pffft_zconvert_zp()` + `pffft_zconvolve_zp()`

Implements the r8brain trick for linear-phase FIRs centered at t=0 with left-hand taps wrapped around the block. One necessary refinement to the proposal: in PFFFT's *unordered* output the coefficients are not stored as interleaved re/im pairs — whole SIMD vectors alternate between real parts and imaginary parts, and F(0)/F(N/2) pack into the first lanes of vectors 0/1 (with the real-valued Nyquist coefficient sitting in an otherwise-imaginary lane). A flat sequential multiply therefore cannot work on unordered buffers directly. Instead this PR provides:

- `pffft_zconvert_zp(setup, in, out, scaling)` — converts an unordered REAL forward spectrum once at filter-setup time: imaginary vector lanes are zeroed, real lanes scaled, the DC/Nyquist pair preserved component-wise.
- `pffft_zconvolve_zp(setup, x, hzp, ab)` — multiplies any number of block spectra against the converted filter using two vector multiplies per re/im vector pair where a full complex multiply needs four (`Y_re = X_re·H_re`, `Y_im = X_im·H_re`).

This keeps the faster *unordered* transforms end-to-end, which is the point of the optimization. Measured vs `zconvolve_scale(.., 1.0)` on M2/NEON, best of 5: **1.53× / 1.60× / 1.59× / 1.47×** at N = 128/512/2048/8192. Both functions return nonzero for non-REAL setups; aliasing (`in == out`) is supported and documented, including the DC/Nyquist lane caveat in the public headers.

C++ wrapper: `convolve(a, b, ab)`, `zconvertZP()` and `convolveZP()` added to the public `Fft<T>` template (raw-pointer and `AlignedVector` forms); COMPLEX instantiations forward unchanged and are rejected by the underlying functions.

### 4. `_USE_MATH_DEFINES`

Now guarded with `#ifndef` so defining it as a compiler-level option no longer conflicts.

### Also included

- **Pre-existing bug fixes surfaced by the new tests:** `pffft_zconvolve_scale_nosimd()` accumulated instead of assigned at the two REAL boundary lanes (bins 0 and N/2), and `test_fft_factors` looped forever under `SIMD_SZ == 1` because `min_fft_size(COMPLEX)` returns 1 there (`N += N_min/2` stepped by zero).
- **CI:** new `build_no-simd_novect` configuration (`PFFFT_USE_SIMD=OFF -DPFFFT_USE_SCALAR_VECT=OFF`) that compiles and ctests the SIMD_SZ==1 branch — previously never executed anywhere.

### Testing

- New ctest coverage: bit-exact agreement between `zconvolve` and `zconvolve_scale(.., 1.0)`; zero-phase round-trip against independently computed time-domain circular convolution; sentinel-based invariant that conversion writes every destination lane; scaling linearity; in-place aliasing equivalence; REAL-only guards; wrapper-level equivalents of all of the above. Red→green verified for the lane-zeroing fix.
- Full suite green in four configurations: default SIMD, `PFFFT_USE_SIMD=OFF` (4×scalar emulation), `PFFFT_USE_SIMD=OFF + PFFFT_USE_SCALAR_VECT=OFF` (SZ=1 nosimd), and float-less double-only builds.
